### PR TITLE
Tiny PR to fix markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you use this code or application, please cite the original paper published by
 
 <h3><a href="http://doc.gdb.tools/smilesDrawer/sd/example/index_light.html">Demo (Canvas)</a></h3>
 <h3><a href="http://doc.gdb.tools/smilesDrawer/sd/example/index_svg.html">Demo (SVG)</a></h3>
+
 ### Compatibility
 
 All the current versions of the major browsers are supported and the application has been tested on the following browsers (versions):


### PR DESCRIPTION
For Github markdown you need to have a newline before your `###` or else it literally renders as `###`, so, this PR fixes a tiny bug in the rendering of your README on Github.com.