### PR TITLE
MathHelper import missing in SvgDrawer (using npm package)

### DIFF
--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -8,6 +8,7 @@ const Line = require('./Line');
 const SvgWrapper = require('./SvgWrapper');
 const ThemeManager = require('./ThemeManager');
 const Vector2 = require('./Vector2');
+const MathHelper = require('./MathHelper');
 
 class SvgDrawer {
   constructor(options) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9539763/97632879-8991e580-1a09-11eb-97b6-890fda8f3acd.png)
