### PR TITLE
Added an option to specify target for svgDrawer as element

### DIFF
--- a/src/SvgWrapper.js
+++ b/src/SvgWrapper.js
@@ -7,7 +7,11 @@ const Vector2 = require('./Vector2');
 
 class SvgWrapper {
   constructor(themeManager, target, options) {
-    this.svg = document.getElementById(target);
+    if (typeof target === 'string' || target instanceof String) {
+      this.svg = document.getElementById(svg);
+    } else {
+      this.svg = target;
+    }
     this.opts = options;
     this.gradientId = 0;
 


### PR DESCRIPTION
This addresses [issue 127](https://github.com/reymond-group/smilesDrawer/issues/127) I just created; the change allows to specify target for svgDrawer as element rather than as element id, just like it works for smilesDrawer.