### PR TITLE
Pass default value `weights = null` to `SvgDrawer.draw()`

### DIFF
--- a/dist/smiles-drawer.js
+++ b/dist/smiles-drawer.js
@@ -5593,7 +5593,7 @@ class Drawer {
     svg.setAttributeNS(null, 'viewBox', '0 0 ' + this.svgDrawer.opts.width + ' ' + this.svgDrawer.opts.height);
     svg.setAttributeNS(null, 'width', this.svgDrawer.opts.width + '');
     svg.setAttributeNS(null, 'height', this.svgDrawer.opts.height + '');
-    this.svgDrawer.draw(data, svg, themeName, infoOnly, highlight_atoms);
+    this.svgDrawer.draw(data, svg, themeName, null, infoOnly, highlight_atoms);
     this.svgDrawer.svgWrapper.toCanvas(canvas, this.svgDrawer.opts.width, this.svgDrawer.opts.height);
   }
   /**

--- a/src/Drawer.js
+++ b/src/Drawer.js
@@ -44,7 +44,7 @@ class Drawer {
     svg.setAttributeNS(null, 'viewBox', '0 0 ' + this.svgDrawer.opts.width + ' ' + this.svgDrawer.opts.height);
     svg.setAttributeNS(null, 'width', this.svgDrawer.opts.width + '');
     svg.setAttributeNS(null, 'height', this.svgDrawer.opts.height + '');
-    this.svgDrawer.draw(data, svg, themeName, infoOnly, highlight_atoms);
+    this.svgDrawer.draw(data, svg, themeName, null, infoOnly, highlight_atoms);
     this.svgDrawer.svgWrapper.toCanvas(canvas, this.svgDrawer.opts.width, this.svgDrawer.opts.height);
   }
 


### PR DESCRIPTION
Resolves #171. Although the `weights` parameter was added to `SvgDrawer.draw()` in f3693b3, the method call in `Drawer.draw()` wasn't updated correspondingly. `Drawer.draw()` could be amended to also take a `weights` argument, which it would pass to `SvgDrawer.draw()`, but this might break existing code even more and would require an update of the documentation of the README.

Example to reproduce:
```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>Title</title>
  <script src="dist/smiles-drawer.js"></script>
</head>
<body>
<canvas id="canvas" style="width: 200px; height: 200px; background-color: lightgrey"></canvas>

<script>
    SmilesDrawer.parse(
        "CCCNC",
        tree => {
            (new SmilesDrawer.Drawer()).draw(tree, 'canvas');
        },
        alert
    );
</script>
</body>
</html>
```

Before the proposed change, this gives an error (`TypeError: this.svgWrapper is null`). With the proposed change, the error is resolved and the structure is displayed correctly.