### PR TITLE
Fix missing zeros in isotope numbers.

### DIFF
--- a/src/SvgWrapper.js
+++ b/src/SvgWrapper.js
@@ -808,8 +808,8 @@ class SvgWrapper {
 
     n.toString().split('').forEach(d => {
       let parsed = parseInt(d);
-      if (parsed) {
-        result += ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹'][parseInt(d)];
+      if (Number.isFinite(parsed)) {
+        result += ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹'][parsed];
       }
     });
 


### PR DESCRIPTION
A minor bugfix for isotope numbers (the digit zero used to disappear due to a superscriptification bug).  This doesn't update any of the bundles in `dist` - my plan is to bundle a few more minor PRs before rebuilding.