### PR TITLE
Always draw carbons if they have isotope or charge modifiers.

### DIFF
--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -1690,6 +1690,12 @@ class DrawerBase {
         isotope = atom.bracket.isotope;
       }
 
+      // If the molecule has less than 3 elements, always write the "C" for carbon
+      // Likewise, if the carbon has a charge or an isotope, always draw it
+      if (charge || isotope || graph.vertices.length < 3) {
+        isCarbon = false;
+      }
+
       if (this.opts.atomVisualization === 'allballs') {
         this.canvasWrapper.drawBall(vertex.position.x, vertex.position.y, element);
       } else if ((atom.isDrawn && (!isCarbon || atom.drawExplicit || isTerminal || atom.hasAttachedPseudoElements)) || this.graph.vertices.length === 1) {

--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -345,11 +345,6 @@ class SvgDrawer {
       let isTerminal = opts.terminalCarbons || element !== 'C' || atom.hasAttachedPseudoElements ? vertex.isTerminal() : false;
       let isCarbon = atom.element === 'C';
 
-      // If the molecule has less than 3 elements, always write the "C" for carbon
-      if (graph.vertices.length < 3) {
-        isCarbon = false;
-      }
-
       // This is a HACK to remove all hydrogens from nitrogens in aromatic rings, as this
       // should be the most common state. This has to be fixed by kekulization
       if (atom.element === 'N' && atom.isPartOfAromaticRing) {
@@ -360,6 +355,12 @@ class SvgDrawer {
         hydrogens = atom.bracket.hcount;
         charge = atom.bracket.charge;
         isotope = atom.bracket.isotope;
+      }
+
+      // If the molecule has less than 3 elements, always write the "C" for carbon
+      // Likewise, if the carbon has a charge or an isotope, always draw it
+      if (charge || isotope || graph.vertices.length < 3) {
+        isCarbon = false;
       }
 
       if (opts.atomVisualization === 'allballs') {


### PR DESCRIPTION
Another small fix to be bundled in the future.  There's still an alignment issue with isotopes, but this takes care of the problem reported in #179 and at least part of #173 (charged carbons are now shown, but there's still no way to make carbons explicit in general).

```
[14CH3][CH-][12CH3]C
```
<img width="480" alt="Screen Shot 2025-03-06 at 10 37 51 AM" src="https://github.com/user-attachments/assets/20753ea1-5cf3-4b46-95fa-d7a6e519e89d" />
