### PR TITLE
Fix rendering atoms with five or more neighbors.

### DIFF
--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -2563,105 +2563,71 @@ class DrawerBase {
 
         this.createNextBond(transVertex, vertex, previousAngle + transVertex.angle, originShortest);
         this.createNextBond(cisVertex, vertex, previousAngle + cisVertex.angle, originShortest);
-      } else if (neighbours.length === 3) {
-        // The vertex with the longest sub-tree should always go straight
-        let d1 = this.graph.getTreeDepth(neighbours[0], vertex.id);
-        let d2 = this.graph.getTreeDepth(neighbours[1], vertex.id);
-        let d3 = this.graph.getTreeDepth(neighbours[2], vertex.id);
+      }
+      else if (neighbours.length > 0) {
+        // Create vertices for all drawn neighbors...
+        const vertices = neighbours.map(neighbour => {
+          let newvertex    = this.graph.vertices[neighbour];
+          let subtreedepth = this.graph.getTreeDepth(neighbour, vertex.id);
+          newvertex.value.subtreeDepth = subtreedepth;
+          return newvertex;
+        })
 
-        let s = this.graph.vertices[neighbours[0]];
-        let l = this.graph.vertices[neighbours[1]];
-        let r = this.graph.vertices[neighbours[2]];
+        // This puts all the longest subtrees on the far side...
+        // TODO: Maybe try to balance this better?
+        vertices.sort((a, b) => (a.value.subtreeDepth < b.value.subtreeDepth))
 
-        s.value.subtreeDepth = d1;
-        l.value.subtreeDepth = d2;
-        r.value.subtreeDepth = d3;
-
-        if (d2 > d1 && d2 > d3) {
-          s = this.graph.vertices[neighbours[1]];
-          l = this.graph.vertices[neighbours[0]];
-          r = this.graph.vertices[neighbours[2]];
-        } else if (d3 > d1 && d3 > d2) {
-          s = this.graph.vertices[neighbours[2]];
-          l = this.graph.vertices[neighbours[0]];
-          r = this.graph.vertices[neighbours[1]];
-        }
-
-        // Create a cross if more than one subtree is of length > 1
-        // or the vertex is connected to a ring
-        if (previousVertex &&
+        if (neighbours.length === 3 &&
+          previousVertex &&
           previousVertex.value.rings.length < 1 &&
-          s.value.rings.length < 1 &&
-          l.value.rings.length < 1 &&
-          r.value.rings.length < 1 &&
-          this.graph.getTreeDepth(l.id, vertex.id) === 1 &&
-          this.graph.getTreeDepth(r.id, vertex.id) === 1 &&
-          this.graph.getTreeDepth(s.id, vertex.id) > 1) {
-
-          s.angle = -vertex.angle;
+          vertices[2].value.rings.length < 1 &&
+          vertices[1].value.rings.length < 1 &&
+          vertices[0].value.rings.length < 1 &&
+          vertices[2].value.subtreeDepth === 1 &&
+          vertices[1].value.subtreeDepth === 1 &&
+          vertices[0].value.subtreeDepth > 1)
+        {
+          // Special logic for adding pinched crosses...
+          vertices[0].angle = -vertex.angle;
           if (vertex.angle >= 0) {
-            l.angle = MathHelper.toRad(30);
-            r.angle = MathHelper.toRad(90);
+            vertices[1].angle = MathHelper.toRad(30);
+            vertices[2].angle = MathHelper.toRad(90);
           } else {
-            l.angle = -MathHelper.toRad(30);
-            r.angle = -MathHelper.toRad(90);
+            vertices[1].angle = -MathHelper.toRad(30);
+            vertices[2].angle = -MathHelper.toRad(90);
           }
 
-          this.createNextBond(s, vertex, previousAngle + s.angle);
-          this.createNextBond(l, vertex, previousAngle + l.angle);
-          this.createNextBond(r, vertex, previousAngle + r.angle);
-        } else {
-          s.angle = 0.0;
-          l.angle = MathHelper.toRad(90);
-          r.angle = -MathHelper.toRad(90);
-
-          this.createNextBond(s, vertex, previousAngle + s.angle);
-          this.createNextBond(l, vertex, previousAngle + l.angle);
-          this.createNextBond(r, vertex, previousAngle + r.angle);
+          this.createNextBond(vertices[0], vertex, previousAngle + vertices[0].angle);
+          this.createNextBond(vertices[1], vertex, previousAngle + vertices[1].angle);
+          this.createNextBond(vertices[2], vertex, previousAngle + vertices[2].angle);
         }
-      } else if (neighbours.length === 4) {
-        // The vertex with the longest sub-tree should always go to the reflected opposide direction
-        let d1 = this.graph.getTreeDepth(neighbours[0], vertex.id);
-        let d2 = this.graph.getTreeDepth(neighbours[1], vertex.id);
-        let d3 = this.graph.getTreeDepth(neighbours[2], vertex.id);
-        let d4 = this.graph.getTreeDepth(neighbours[3], vertex.id);
+        else {
+          // Divide the remaining space evenly among all neighbors...
+          const totalNeighbors = neighbours.length + (previousVertex? 1 : 0);
+          const angleDelta = 2 * Math.PI / totalNeighbors;
+          let angle = angleDelta;
+          let index = 0;
 
-        let w = this.graph.vertices[neighbours[0]];
-        let x = this.graph.vertices[neighbours[1]];
-        let y = this.graph.vertices[neighbours[2]];
-        let z = this.graph.vertices[neighbours[3]];
+          if (neighbours.length % 2 !== 0) {
+            // If there are an even number, the longest neighbor goes directly across.
+            vertices[0].angle = 0.0;
+            this.createNextBond(vertices[0], vertex, previousAngle);
+            index = 1;
+          }
+          else {
+            // Otherwise, the two longest neighbors split the difference.
+            angle /= 2;
+          }
 
-        w.value.subtreeDepth = d1;
-        x.value.subtreeDepth = d2;
-        y.value.subtreeDepth = d3;
-        z.value.subtreeDepth = d4;
-
-        if (d2 > d1 && d2 > d3 && d2 > d4) {
-          w = this.graph.vertices[neighbours[1]];
-          x = this.graph.vertices[neighbours[0]];
-          y = this.graph.vertices[neighbours[2]];
-          z = this.graph.vertices[neighbours[3]];
-        } else if (d3 > d1 && d3 > d2 && d3 > d4) {
-          w = this.graph.vertices[neighbours[2]];
-          x = this.graph.vertices[neighbours[0]];
-          y = this.graph.vertices[neighbours[1]];
-          z = this.graph.vertices[neighbours[3]];
-        } else if (d4 > d1 && d4 > d2 && d4 > d3) {
-          w = this.graph.vertices[neighbours[3]];
-          x = this.graph.vertices[neighbours[0]];
-          y = this.graph.vertices[neighbours[1]];
-          z = this.graph.vertices[neighbours[2]];
+          while (index < neighbours.length) {
+            vertices[index + 0].angle =  angle;
+            vertices[index + 1].angle = -angle;
+            this.createNextBond(vertices[index + 0], vertex, previousAngle + angle);
+            this.createNextBond(vertices[index + 1], vertex, previousAngle - angle);
+            angle += angleDelta;
+            index += 2;
+          }
         }
-
-        w.angle = -MathHelper.toRad(36);
-        x.angle = MathHelper.toRad(36);
-        y.angle = -MathHelper.toRad(108);
-        z.angle = MathHelper.toRad(108);
-
-        this.createNextBond(w, vertex, previousAngle + w.angle);
-        this.createNextBond(x, vertex, previousAngle + x.angle);
-        this.createNextBond(y, vertex, previousAngle + y.angle);
-        this.createNextBond(z, vertex, previousAngle + z.angle);
       }
     }
   }


### PR DESCRIPTION
This fixes the rendering of atoms with five or more neighbors.  Five to seven neighbors work great, but things get weird with eight or more (possibly because the neighbors are too close and overlap resolution kicks in?) and they no longer draw evenly spaced.

Fixes the second and third test cases from #2; the first one has bridged-ring-related complications.