### PR TITLE
Disable inconsistent second-level pseudo-elements.

### DIFF
--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -3100,6 +3100,7 @@ class DrawerBase {
       }
     }
 
+    /*
     // The second pass
     for (var i = 0; i < this.graph.vertices.length; i++) {
       const vertex = this.graph.vertices[i];
@@ -3126,12 +3127,21 @@ class DrawerBase {
 
         const pseudoElements = neighbour.getAttachedPseudoElements();
 
-        if (pseudoElements.hasOwnProperty('0O') && pseudoElements.hasOwnProperty('3C')) {
-          neighbour.isDrawn = false;
-          vertex.value.attachPseudoElement('Ac', '', 0);
+        if (neighbour.element === 'C' && pseudoElements.hasOwnProperty('0O') && pseudoElements.hasOwnProperty('3C')) {
+          if (pseudoElements['0O'].count === 1 && pseudoElements['3C'].count === 1) {
+            neighbour.isDrawn = false;
+            vertex.value.attachPseudoElement('Ac', '', 0);
+          }
+        }
+        else if (neighbour.element === 'S' && pseudoElements.hasOwnProperty('0O') && pseudoElements.hasOwnProperty('3C')) {
+          if (pseudoElements['0O'].count === 2 && pseudoElements['3C'].count === 1) {
+            neighbour.isDrawn = false;
+            vertex.value.attachPseudoElement('Me', '', 0);
+          }
         }
       }
     }
+    */
   }
 }
 


### PR DESCRIPTION
This is a "fix" for #137.

I added code to differentiate mesylate and acetyl pseudo-elements.  This worked for the test case given in #137, but further testing showed it to be fairly unreliable; it often wouldn't correctly detect either group.  So I've disabled the entire second pass of pseudo-element detection until we can add something more robust.  The result is that mesylate now draws as H₃CO₂S or SO₂CH₃, which should be acceptable for now.

The test SMILES from the original bug report:
```
C1=C[N](N=C1)C2CN([S](C)(=O)=O)C2
```

Another one I was using:
```
CCCC(S(=O)(=O)C)CC(C(C)=O)CCCC
```