### PR TITLE
Fix Asymmetric Stars

### DIFF
--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -2520,6 +2520,7 @@ export default class DrawerBase {
 
         if (neighbours.length === 3
           && previousVertex
+          && previousVertex.parentVertexId !== null
           && previousVertex.value.rings.length < 1
           && vertices[2].value.rings.length < 1
           && vertices[1].value.rings.length < 1


### PR DESCRIPTION
Treat four-neighbor atoms at the origin the same as at the end (that is, don't try to put a pinched pair at the first "inside" atom of a chain).  This fixes the asymmetry reported in #223.