### PR TITLE
Fix bridgedRing check in SvgDrawer.drawEdges()

### DIFF
--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -162,7 +162,7 @@ export default class SvgDrawer {
         });
 
         // Draw ring for implicitly defined aromatic rings
-        if (!this.bridgedRing) {
+        if (!preprocessor.bridgedRing) {
             for (let i = 0; i < rings.length; i++) {
                 let ring = rings[i];
 


### PR DESCRIPTION
## Summary

`SvgDrawer.drawEdges()` (line 164) checks `this.bridgedRing` to decide whether to draw aromatic ring circles. However, `bridgedRing` is never set on the `SvgDrawer` instance — it is a property of the `DrawerBase` preprocessor. Because `this.bridgedRing` is always `undefined`, the condition `!this.bridgedRing` is always `true`, and aromatic circles are drawn unconditionally — even for bridged-ring molecules where only dashed Kekulé lines should appear.

The fix changes `this.bridgedRing` to `preprocessor.bridgedRing`, which is the local variable already in scope from the `drawEdges()` method and correctly reflects whether the molecule contains bridged rings.

## Before / After

For a bridged-ring molecule like `COc1ncncc1-c1nc2c(s1)CN(C(=O)c1cn3c4c(cccc14)CCC3)C2`:

- **Before:** Both aromatic circles AND dashed Kekulé lines are drawn (circles should be suppressed for bridged rings)
- **After:** Only dashed Kekulé lines are drawn, matching the behavior of the [official demo](https://doc.gdb.tools/smilesDrawer/sd/example/index_light.html)

## Change

One-line fix in `src/SvgDrawer.js`:

```diff
-        if (!this.bridgedRing) {
+        if (!preprocessor.bridgedRing) {
```