### PR TITLE
Improve dashed bond styling for aromatic rings

### DIFF
--- a/src/SvgWrapper.js
+++ b/src/SvgWrapper.js
@@ -492,9 +492,9 @@ export default class SvgWrapper {
      */
     drawLine(line, dashed = false, gradient = null, linecap = 'round') {
         let stylesArr = [
-                ['stroke-width', this.opts.bondThickness],
+                ['stroke-width', dashed ? this.opts.bondThickness * 0.6 : this.opts.bondThickness],
                 ['stroke-linecap', linecap],
-                ['stroke-dasharray', dashed ? '5, 5' : 'none'],
+                ['stroke-dasharray', dashed ? '2, 2' : 'none'],
             ],
             l = line.getLeftVector(),
             r = line.getRightVector(),


### PR DESCRIPTION
## Summary

- Make dashed lines for aromatic bonds thinner (60% of normal `bondThickness`) so they are visually distinct from solid bonds
- Use a tighter dash pattern (`2, 2` instead of `5, 5`) for cleaner aromatic ring rendering

## Before / After

| Before | After |
|--------|-------|
| Dashes use full `bondThickness` | Dashes use `0.6 × bondThickness` |
| Dash pattern `5, 5` (long gaps) | Dash pattern `2, 2` (tight, uniform) |

The current `5, 5` dash pattern with full bond thickness makes dashed bonds look heavy and hard to distinguish from solid bonds at smaller sizes. The tighter, thinner dashes produce a cleaner rendering that better communicates aromaticity.

## Changes

One file changed: `src/SvgWrapper.js` — two lines in `drawLine()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)