### PR TITLE
Added React example framework specific documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,45 @@ Current Version: **2.2.0**
 <!--usage-->
 <Molecule smiles="CCCO" />
 ```
-
 </details>
+
+<details>
+  <summary>React</summary>
+
+```jsx
+import { useEffect, useRef } from "react";
+import SmilesDrawer from "smiles-drawer";
+
+export function SmilesViewer({
+  smilesStr,
+  type = "svg",
+  width = 400,
+  height = 400,
+}) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!smilesStr || !containerRef.current) return;
+
+    const sd = new SmilesDrawer.SmiDrawer({ width, height });
+    sd.draw(smilesStr, containerRef.current);
+  }, [smilesStr, width, height]);
+
+  if (type === "img") {
+    return (
+      <img
+        ref={containerRef}
+        style={{ width, height }}
+        alt="SMILES structure"
+      />
+    );
+  }
+  return <svg ref={containerRef} width={width} height={height} />;
+}
+```
+</details>
+
+
 
 ### Please cite
 


### PR DESCRIPTION
Code snippet is line for line equivalent (barring some error handling/styling) to what we will probably use for [Materials Cloud OPTIMADE client](https://optimadeclient.materialscloud.io/).

invoking the component is simple 
<SmilesViewer smilesStr={smilesStr}>

It's a very simple wrapper and perhaps its unneccessary to have in the docs, but feel free to merge if you like