### PR TITLE
Fix ReactionDrawer options usage.

### DIFF
--- a/src/ReactionDrawer.js
+++ b/src/ReactionDrawer.js
@@ -8,10 +8,10 @@ export default class ReactionDrawer {
     /**
      * The constructor for the class ReactionDrawer.
      *
-     * @param {Object} options An object containing reaction drawing specitic options.
+     * @param {Object} reactionOptions An object containing reaction drawing specific options.
      * @param {Object} moleculeOptions An object containing molecule drawing specific options.
      */
-    constructor(options, moleculeOptions) {
+    constructor(reactionOptions, moleculeOptions) {
         this.drawer  = new SvgDrawer(moleculeOptions);
         this.molOpts = this.drawer.opts;
 
@@ -38,7 +38,7 @@ export default class ReactionDrawer {
             },
         };
 
-        this.opts = Options.extend(true, this.defaultOptions, options);
+        this.opts = Options.extend(true, this.defaultOptions, reactionOptions);
     }
 
     /**


### PR DESCRIPTION
This fixes a bug where the `ReactionDrawer` constructor could try to use option values that don't exist.

It happens when the user creates a `ReactionDrawer` manually and doesn't specify one of several molecule options (`scale`, `fontSize`, or `bondLength`).  The fix is to create the internal `SvgDrawer` first, and then use its options - the `SvgDrawer` constructor merges the user-provided options with the defaults, so all the values are guaranteed to exist.