### PR TITLE
Improve reaction arrow text handling.

### DIFF
--- a/src/ReactionDrawer.js
+++ b/src/ReactionDrawer.js
@@ -224,7 +224,7 @@ export default class ReactionDrawer {
         elements.push({
             svg:      topText.svg,
             height:   topText.height,
-            width:    this.opts.arrow.length * this.opts.scale,
+            width:    topText.width,
             offsetX:  -(this.opts.arrow.length * this.opts.scale + this.opts.spacing) + centerOffsetX,
             offsetY:  -(topText.height / 2.0) - this.opts.arrow.margin,
             position: 'relative',
@@ -244,7 +244,7 @@ export default class ReactionDrawer {
         elements.push({
             svg:      bottomText.svg,
             height:   bottomText.height,
-            width:    this.opts.arrow.length * this.opts.scale,
+            width:    bottomText.width,
             offsetX:  -(this.opts.arrow.length * this.opts.scale + this.opts.spacing) + centerOffsetX,
             offsetY:  bottomText.height / 2.0 + this.opts.arrow.margin,
             position: 'relative',

--- a/src/SvgWrapper.js
+++ b/src/SvgWrapper.js
@@ -944,7 +944,7 @@ export default class SvgWrapper {
         style.appendChild(document.createTextNode(`
             .text {
                 font: ${fontSize}pt ${fontFamily};
-                dominant-baseline: ideographic;
+                dominant-baseline: alphabetic;
             }
         `));
         svg.appendChild(style);
@@ -952,74 +952,52 @@ export default class SvgWrapper {
         let textElem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
         textElem.setAttributeNS(null, 'class', 'text');
 
-        let maxLineWidth = 0.0;
-        let totalHeight = 0.0;
-
         let lines = [];
-
         text.split('\n').forEach((line) => {
             let dims = SvgWrapper.measureText(line, fontSize, fontFamily, 1.0);
             if (dims.width >= maxWidth) {
-                let totalWordsWidth = 0.0;
-                let maxWordsHeight = 0.0;
-                let words = line.split(' ');
-                let offset = 0;
+                const words  = line.split(' ');
+                let   offset = 0;
 
                 for (let i = 0; i < words.length; i++) {
-                    let wordDims = SvgWrapper.measureText(words[i], fontSize, fontFamily, 1.0);
+                    const part = words.slice(offset, i + 1).join(' ');
+                    const dims = SvgWrapper.measureText(part, fontSize, fontFamily);
 
-                    if (totalWordsWidth + wordDims.width > maxWidth) {
-                        lines.push({
-                            text:   words.slice(offset, i).join(' '),
-                            width:  totalWordsWidth,
-                            height: maxWordsHeight,
-                        });
-
-                        totalWordsWidth = 0.0;
-                        maxWordsHeight = 0.0;
+                    if (dims.width > maxWidth && i > offset) {
+                        lines.push(words.slice(offset, i).join(' '));
                         offset = i;
                     }
-
-                    if (wordDims.height > maxWordsHeight) {
-                        maxWordsHeight = wordDims.height;
-                    }
-
-                    totalWordsWidth += wordDims.width;
                 }
 
                 if (offset < words.length) {
-                    lines.push({
-                        text:   words.slice(offset, words.length).join(' '),
-                        width:  totalWordsWidth,
-                        height: maxWordsHeight,
-                    });
+                    lines.push(words.slice(offset, words.length).join(' '));
                 }
             }
             else {
-                lines.push({
-                    text:   line,
-                    width:  dims.width,
-                    height: dims.height,
-                });
+                lines.push(line);
             }
         });
 
-        lines.forEach((line) => {
-            totalHeight += line.height;
+        let maxLineWidth = 0.0;
+        lines.forEach((line, i) => {
             let tspanElem = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
             tspanElem.setAttributeNS(null, 'fill', themeManager.getColor('C'));
-            tspanElem.textContent = line.text;
+            tspanElem.textContent = line;
             tspanElem.setAttributeNS(null, 'x', '0px');
-            tspanElem.setAttributeNS(null, 'y', `${totalHeight}px`);
+            tspanElem.setAttributeNS(null, 'y', `${i+1}em`);
             textElem.appendChild(tspanElem);
 
-            if (line.width > maxLineWidth) {
-                maxLineWidth = line.width;
-            }
+            const dims = SvgWrapper.measureText(line, fontSize, fontFamily);
+            maxLineWidth = Math.max(maxLineWidth, dims.width);
         });
+
+        textElem.setAttributeNS(null, 'transform',   `translate(${maxLineWidth / 2}, 0)`);
+        textElem.setAttributeNS(null, 'text-anchor', 'middle');
 
         svg.appendChild(textElem);
 
-        return {svg: svg, width: maxLineWidth, height: totalHeight};
+        // The extra 0.4 here it to account for any subscripts on the bottom line.
+        // The factor of 4 / 3 is to convert from points to CSS pixels (1in = 72pt = 96px).
+        return {svg: svg, width: maxLineWidth, height: (lines.length + 0.4) * fontSize * 4 / 3};
     }
 }

--- a/test/visual/reaction-text.html
+++ b/test/visual/reaction-text.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" type="text/css" href="./visual-tests.css" />
+    <script type="text/javascript" src="./visual-tests.js"></script>
+    <script type="text/javascript" src="../../dist/smiles-drawer.dev.js"></script>
+    <title>Text Alignment Tests</title>
+    <script type="module" defer>
+      const TESTS = [
+        {
+          desc: 'The subscripts on the reaction arrow text should be fully visible.',
+          cause: 'The height calculation in SvgWrapper.writeText() didn\'t account for descenders/subscripts.',
+          status: 'passing',
+          smiles: [
+            '[Pb]>[OH3]>[Au] __{"textBelowArrow": "C₂H₆"}__',
+          ],
+          links: [
+            'https://github.com/reymond-group/smilesDrawer/issues/241'
+          ]
+        },
+
+        {
+          desc: 'Long lines of reaction arrow text should wrap at about the arrow length.',
+          cause: 'The width calculation in SvgWrapper.writeText() didn\'t account for spaces, so lines could be too long.',
+          status: 'passing',
+          smiles: [
+            '[Pb]>OS(=O)(=O)O>[Au] __{"textAboveArrow": "a a a a a a a a a a a a a a a a a a a a a a a", "textBelowArrow": "b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b "}__',
+          ],
+        },
+
+        {
+          desc: 'Extra-long lines of reaction text should not be cut off (but might overlap the molecules).',
+          cause: 'ReactionDrawer used to cap the text size to the length of the reaction arrow, so long lines would be cut off.',
+          status: 'passing',
+          smiles: [
+            '[Pb]>OS(=O)(=O)O>[Au] __{"textBelowArrow": "Humuhumunukunukuāpuaʻa", "textAboveArrow": "Lauwiliwilinukunukuʻoiʻoi"}__',
+            '[Pb]>OS(=O)(=O)O>[Au] __{"textBelowArrow": "antidisestablishmentarianism is the first word", "textAboveArrow": "antidisestablishmentarianism is the first word"}__',
+            '[Pb]>OS(=O)(=O)O>[Au] __{"textBelowArrow": "there is antidisestablishmentarianism in the middle", "textAboveArrow": "there is antidisestablishmentarianism in the middle"}__',
+            '[Pb]>OS(=O)(=O)O>[Au] __{"textBelowArrow": "the last word is antidisestablishmentarianism", "textAboveArrow": "the last word is antidisestablishmentarianism"}__',
+          ],
+        },
+
+        {
+          desc: 'The formula for oil of vitriol (sulphuric acid) should have two hydrogens.',
+          cause: undefined,
+          status: 'failing',
+          smiles: [
+            '[Pb]>OS(=O)(=O)O>[Au]',
+          ],
+          links: [
+            'https://github.com/reymond-group/smilesDrawer/issues/262'
+          ]
+        },
+      ];
+
+      // await loadSmilesDrawer();
+      const container = document.getElementById('tests');
+      loadTests(container, TESTS);
+    </script>
+  </head>
+  <body>
+    <h1>Text Alignment Tests</h1>
+    <div id="tests"></div>
+  </body>
+</html>

--- a/test/visual/reaction-text.html
+++ b/test/visual/reaction-text.html
@@ -26,7 +26,7 @@
           cause: 'The width calculation in SvgWrapper.writeText() didn\'t account for spaces, so lines could be too long.',
           status: 'passing',
           smiles: [
-            '[Pb]>OS(=O)(=O)O>[Au] __{"textAboveArrow": "a a a a a a a a a a a a a a a a a a a a a a a", "textBelowArrow": "b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b "}__',
+            '[Pb]>>[Au] __{"textAboveArrow": "a a a a a a a a a a a a a a a a a a a a a a a", "textBelowArrow": "b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b "}__',
           ],
         },
 
@@ -35,10 +35,10 @@
           cause: 'ReactionDrawer used to cap the text size to the length of the reaction arrow, so long lines would be cut off.',
           status: 'passing',
           smiles: [
-            '[Pb]>OS(=O)(=O)O>[Au] __{"textBelowArrow": "Humuhumunukunukuāpuaʻa", "textAboveArrow": "Lauwiliwilinukunukuʻoiʻoi"}__',
-            '[Pb]>OS(=O)(=O)O>[Au] __{"textBelowArrow": "antidisestablishmentarianism is the first word", "textAboveArrow": "antidisestablishmentarianism is the first word"}__',
-            '[Pb]>OS(=O)(=O)O>[Au] __{"textBelowArrow": "there is antidisestablishmentarianism in the middle", "textAboveArrow": "there is antidisestablishmentarianism in the middle"}__',
-            '[Pb]>OS(=O)(=O)O>[Au] __{"textBelowArrow": "the last word is antidisestablishmentarianism", "textAboveArrow": "the last word is antidisestablishmentarianism"}__',
+            '[Pb]>>[Au] __{"textAboveArrow": "Humuhumunukunukuāpuaʻa", "textBelowArrow": "Lauwiliwilinukunukuʻoiʻoi"}__',
+            '[Pb]>>[Au] __{"textAboveArrow": "antidisestablishmentarianism is the first word", "textBelowArrow": "antidisestablishmentarianism is the first word"}__',
+            '[Pb]>>[Au] __{"textAboveArrow": "there is antidisestablishmentarianism in the middle", "textBelowArrow": "there is antidisestablishmentarianism in the middle"}__',
+            '[Pb]>>[Au] __{"textAboveArrow": "the last word is antidisestablishmentarianism", "textBelowArrow": "the last word is antidisestablishmentarianism"}__',
           ],
         },
 

--- a/test/visual/visual-tests.js
+++ b/test/visual/visual-tests.js
@@ -10,7 +10,8 @@ function e(type, attrs = {}, text = undefined) {
 }
 
 function loadTests(element, tests) {
-    const drawer = new SmilesDrawer.SmiDrawer({width: 200, height: 150, compactDrawing: false})
+    const mol_drawer = new SmilesDrawer.SmiDrawer({width: 200, height: 150, compactDrawing: false})
+    const rxn_drawer = new SmilesDrawer.SmiDrawer({width: 500, height: 150, compactDrawing: false})
 
     tests.forEach((test) => {
         const div   = e('div', {class: 'test-case'})
@@ -26,10 +27,17 @@ function loadTests(element, tests) {
         }
 
         test.smiles.forEach((smiles) => {
-            const chunks  = smiles.split(/\s+/)
+            if (smiles.includes('__')) {
+                var chunks = [smiles, smiles.split(' ', 1)];
+            }
+            else {
+                var chunks = smiles.split(/\s+/)
+            }
+
             const frame   = e('div', {class: 'frame'})
             const caption = e('div', {class: 'caption', title: chunks[0]}, chunks[1] || chunks[0])
 
+            const drawer = smiles.includes('>')? rxn_drawer : mol_drawer;
             drawer.draw(chunks[0], 'canvas', 'light',
                 canvas => {frame.append(canvas)},
                 error  => {console.log(error)}


### PR DESCRIPTION
This contains fixes and improvements for reaction arrow text that I found while working on text measurement for #258:
- Line width calculations now correctly take spaces into account.
- Line height is now consistently one em (as opposed to being based on actual text height, which meant that ascenders, descenders, and subscripts could change the line height).
- Extra-long lines (with no spaces) are no longer cut off when they are longer than the reaction arrow.  There's now a risk of overlapping a molecule drawing, but this is only _possibly_ ugly, while clipping the text was definitely ugly.