### PR TITLE
Harden test workflow with Node, concurrency, and permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,24 +5,36 @@ on:
   push:
     branches:
       - master
-      - dev-alex
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run CI tests
         run: npm run test:ci


### PR DESCRIPTION
Now that master is protected im also hardening the tests. 
What changed: 
- Add concurrency: tests are fast but still this saves runners minutes.
- Permissions: restrict to read
- npm ci instead of npm install
- test on Node matrix. I noticed that publish.yml uses Node 24 while the current test.yml was using Node 20. Test for both, although we can probably just stay with Node 24 .