### PR TITLE
Allow weight array length mismatches.

### DIFF
--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -435,18 +435,23 @@ export default class SvgDrawer {
             return;
         }
 
+        let vertex_ids = this.preprocessor.graph.atomIdxToVertexId;
+        if (weights.length < vertex_ids.length) {
+            vertex_ids = vertex_ids.slice(0, weights.length);
+        }
+        else if (weights.length > vertex_ids.length) {
+            console.warn(`More weights (${weights.length}) than heavy atoms (${vertex_ids.length}); truncating.`);
+            weights = weights.slice(0, vertex_ids.length);
+        }
+
         if (weights.every(w => w === 0)) {
             return;
         }
 
-        if (weights.length !== this.preprocessor.graph.atomIdxToVertexId.length) {
-            throw new Error('The number of weights supplied must be equal to the number of (heavy) atoms in the molecule.');
-        }
-
         let points = [];
 
-        for (const atomIdx of this.preprocessor.graph.atomIdxToVertexId) {
-            let vertex = this.preprocessor.graph.vertices[atomIdx];
+        for (const vertex_id of vertex_ids) {
+            let vertex = this.preprocessor.graph.vertices[vertex_id];
             points.push(new Vector2(
                 vertex.position.x - this.svgWrapper.minX,
                 vertex.position.y - this.svgWrapper.minY)


### PR DESCRIPTION
This makes weights a little more forgiving to work with (especially in a UI/playground, where users will be entering weights one at a time):
- If there are fewer weights than heavy atoms, just highlight the first few atoms.
- If there are more weights than heavy atoms, ignore the last few weights.