### PR TITLE
Add polymer repeat-unit [ ]n overlay mode for wildcard endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The following options are available:
 | Use experimental features                                       | experimental                | boolean                             | false         |
 | Show Terminal Carbons (CH3)                                     | terminalCarbons             | boolean                             | false         |
 | Show all carbon labels (C/CH/CH2/CH3)                          | showAllCarbonLabels         | boolean                             | false         |
+| Exclude ring carbons when showing all carbon labels             | showAllCarbonLabelsExcludeRings | boolean                          | false         |
 | Show explicit hydrogens                                         | explicitHydrogens           | boolean                             | false         |
 | Overlap sensitivity                                             | overlapSensitivity          | number                              | 0.42          |
 | # of overlap resolution iterations                              | overlapResolutionIterations | number                              | 1             |
@@ -217,6 +218,7 @@ The default options are defined as follows:
     debug: false,
     terminalCarbons: false,
     showAllCarbonLabels: false,
+    showAllCarbonLabelsExcludeRings: false,
     explicitHydrogens: false,
     overlapSensitivity: 0.42,
     overlapResolutionIterations: 1,
@@ -261,6 +263,7 @@ The default options are defined as follows:
 ```
 
 When `showAllCarbonLabels` is `true`, carbon atoms are always rendered with explicit labels (`C`, `CH`, `CH2`, `CH3`) instead of being omitted by skeletal display rules.
+If `showAllCarbonLabelsExcludeRings` is also `true`, carbons that are part of rings keep the default skeletal style while acyclic carbons remain explicitly labeled.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ The following options are available:
 | Padding                                                         | padding                     | number                              | 20.0          |
 | Use experimental features                                       | experimental                | boolean                             | false         |
 | Show Terminal Carbons (CH3)                                     | terminalCarbons             | boolean                             | false         |
+| Show all carbon labels (C/CH/CH2/CH3)                          | showAllCarbonLabels         | boolean                             | false         |
 | Show explicit hydrogens                                         | explicitHydrogens           | boolean                             | false         |
 | Overlap sensitivity                                             | overlapSensitivity          | number                              | 0.42          |
 | # of overlap resolution iterations                              | overlapResolutionIterations | number                              | 1             |
@@ -215,6 +216,7 @@ The default options are defined as follows:
     isomeric: true,
     debug: false,
     terminalCarbons: false,
+    showAllCarbonLabels: false,
     explicitHydrogens: false,
     overlapSensitivity: 0.42,
     overlapResolutionIterations: 1,
@@ -257,6 +259,8 @@ The default options are defined as follows:
     }
 };
 ```
+
+When `showAllCarbonLabels` is `true`, carbon atoms are always rendered with explicit labels (`C`, `CH`, `CH2`, `CH3`) instead of being omitted by skeletal display rules.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The following options are available:
 | Show Terminal Carbons (CH3)                                     | terminalCarbons             | boolean                             | false         |
 | Show all carbon labels (C/CH/CH2/CH3)                          | showAllCarbonLabels         | boolean                             | false         |
 | Exclude ring carbons when showing all carbon labels             | showAllCarbonLabelsExcludeRings | boolean                          | false         |
+| Polymer repeat-unit overlay for wildcard endpoints              | polymerDisplayMode          | string ['none', 'bracket-n']        | 'none'        |
 | Show explicit hydrogens                                         | explicitHydrogens           | boolean                             | false         |
 | Overlap sensitivity                                             | overlapSensitivity          | number                              | 0.42          |
 | # of overlap resolution iterations                              | overlapResolutionIterations | number                              | 1             |
@@ -219,6 +220,7 @@ The default options are defined as follows:
     terminalCarbons: false,
     showAllCarbonLabels: false,
     showAllCarbonLabelsExcludeRings: false,
+    polymerDisplayMode: 'none',
     explicitHydrogens: false,
     overlapSensitivity: 0.42,
     overlapResolutionIterations: 1,
@@ -264,6 +266,7 @@ The default options are defined as follows:
 
 When `showAllCarbonLabels` is `true`, carbon atoms are always rendered with explicit labels (`C`, `CH`, `CH2`, `CH3`) instead of being omitted by skeletal display rules.
 If `showAllCarbonLabelsExcludeRings` is also `true`, carbons that are part of rings keep the default skeletal style while acyclic carbons remain explicitly labeled.
+`polymerDisplayMode: 'bracket-n'` enables a display-only `[ ]n` overlay for structures using wildcard (`*`) repeat endpoints.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ The default options are defined as follows:
 
 When `showAllCarbonLabels` is `true`, carbon atoms are always rendered with explicit labels (`C`, `CH`, `CH2`, `CH3`) instead of being omitted by skeletal display rules.
 If `showAllCarbonLabelsExcludeRings` is also `true`, carbons that are part of rings keep the default skeletal style while acyclic carbons remain explicitly labeled.
-`polymerDisplayMode: 'bracket-n'` enables a display-only `[ ]n` overlay for structures using wildcard (`*`) repeat endpoints.
+`polymerDisplayMode: 'bracket-n'` enables a display-only `[ ]n` overlay for strict repeat-endpoint patterns (exactly two wildcard `*` atoms, each terminal, and appearing at the first/last atom positions in SMILES order). Other wildcard usages keep the default rendering.
 
 ### Usage
 

--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -53,6 +53,7 @@ export default class DrawerBase {
             isomeric:                    true,
             debug:                       false,
             terminalCarbons:             false,
+            showAllCarbonLabels:         false,
             explicitHydrogens:           true,
             overlapSensitivity:          0.42,
             overlapResolutionIterations: 1,
@@ -1797,6 +1798,11 @@ export default class DrawerBase {
             let dir = vertex.getTextDirection(this.graph.vertices);
             let isTerminal = this.opts.terminalCarbons || element !== 'C' || atom.hasAttachedPseudoElements ? vertex.isTerminal() : false;
             let isCarbon = atom.element === 'C';
+
+            if (this.opts.showAllCarbonLabels && element === 'C') {
+                isCarbon = false;
+                isTerminal = true;
+            }
             // This is a HACK to remove all hydrogens from nitrogens in aromatic rings, as this
             // should be the most common state. This has to be fixed by kekulization
             if (atom.element === 'N' && atom.isPartOfAromaticRing) {

--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -54,6 +54,7 @@ export default class DrawerBase {
             debug:                       false,
             terminalCarbons:             false,
             showAllCarbonLabels:         false,
+            showAllCarbonLabelsExcludeRings: false,
             explicitHydrogens:           true,
             overlapSensitivity:          0.42,
             overlapResolutionIterations: 1,
@@ -1800,8 +1801,13 @@ export default class DrawerBase {
             let isCarbon = atom.element === 'C';
 
             if (this.opts.showAllCarbonLabels && element === 'C') {
-                isCarbon = false;
-                isTerminal = true;
+                const isRingCarbon = atom.rings && atom.rings.length > 0;
+                const shouldLabel = !(this.opts.showAllCarbonLabelsExcludeRings && isRingCarbon);
+
+                if (shouldLabel) {
+                    isCarbon = false;
+                    isTerminal = true;
+                }
             }
             // This is a HACK to remove all hydrogens from nitrogens in aromatic rings, as this
             // should be the most common state. This has to be fixed by kekulization

--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -55,6 +55,7 @@ export default class DrawerBase {
             terminalCarbons:             false,
             showAllCarbonLabels:         false,
             showAllCarbonLabelsExcludeRings: false,
+            polymerDisplayMode:          'none',
             explicitHydrogens:           true,
             overlapSensitivity:          0.42,
             overlapResolutionIterations: 1,

--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -17,6 +17,10 @@ export default class SvgDrawer {
         this.opts = this.preprocessor.opts;
         this.clear = clear;
         this.svgWrapper = null;
+        this.polymerOverlayState = {
+            enabled: false,
+            wildcardVertexIds: new Set(),
+        };
     }
 
     /**
@@ -68,6 +72,8 @@ export default class SvgDrawer {
         // Set the canvas to the appropriate size
         this.svgWrapper.determineDimensions(preprocessor.graph.vertices);
 
+        this.polymerOverlayState = this.getPolymerOverlayState();
+
         // Do the actual drawing
         this.drawAtomHighlights(preprocessor.opts.debug);
         this.drawEdges(preprocessor.opts.debug);
@@ -98,22 +104,69 @@ export default class SvgDrawer {
     }
 
     /**
+     * Return whether polymer overlay should be enabled and which wildcard vertices are involved.
+     * Overlay is intentionally strict to avoid false positives in generic wildcard-containing SMILES.
+     */
+    getPolymerOverlayState() {
+        if (this.opts.polymerDisplayMode !== 'bracket-n') {
+            return {enabled: false, wildcardVertexIds: new Set()};
+        }
+
+        const graph = this.preprocessor.graph;
+        const wildcardVertices = graph.vertices.filter((vertex) => vertex.value.element === '*');
+        if (wildcardVertices.length !== 2) {
+            return {enabled: false, wildcardVertexIds: new Set()};
+        }
+
+        const smilesOrders = graph.vertices.map((vertex) => vertex.value.smilesOrder);
+        if (smilesOrders.some((order) => typeof order !== 'number')) {
+            return {enabled: false, wildcardVertexIds: new Set()};
+        }
+
+        const minOrder = Math.min(...smilesOrders);
+        const maxOrder = Math.max(...smilesOrders);
+        const wildcardOrders = wildcardVertices.map((vertex) => vertex.value.smilesOrder);
+        if (!wildcardOrders.includes(minOrder) || !wildcardOrders.includes(maxOrder)) {
+            return {enabled: false, wildcardVertexIds: new Set()};
+        }
+
+        const wildcardIds = new Set(wildcardVertices.map((vertex) => vertex.id));
+
+        for (const wildcard of wildcardVertices) {
+            // Wildcards should be simple terminal endpoints.
+            if (wildcard.getNeighbourCount() !== 1) {
+                return {enabled: false, wildcardVertexIds: new Set()};
+            }
+
+            if (wildcard.value.rings && wildcard.value.rings.length > 0) {
+                return {enabled: false, wildcardVertexIds: new Set()};
+            }
+
+            const attachedId = wildcard.neighbours[0];
+            const attached = graph.vertices[attachedId];
+            if (!attached || attached.value.element === '*') {
+                return {enabled: false, wildcardVertexIds: new Set()};
+            }
+        }
+
+        return {enabled: true, wildcardVertexIds: wildcardIds};
+    }
+
+    /**
      * Draw a polymer repeat-unit [ ]n overlay for wildcard endpoints (*).
      * This is a display-only overlay and does not alter chemical graph semantics.
      */
     drawPolymerRepeatOverlay() {
-        if (this.opts.polymerDisplayMode !== 'bracket-n') {
+        if (!this.polymerOverlayState.enabled) {
             return;
         }
 
         const vertices = this.preprocessor.graph.vertices.filter((vertex) => {
             if (!vertex.value.isDrawn) return false;
-            if (vertex.value.element === '*') return false;
+            if (this.polymerOverlayState.wildcardVertexIds.has(vertex.id)) return false;
             return true;
         });
-
-        const wildcardCount = this.preprocessor.graph.vertices.filter((vertex) => vertex.value.element === '*').length;
-        if (wildcardCount < 2 || vertices.length < 2) {
+        if (vertices.length < 2) {
             return;
         }
 
@@ -266,7 +319,7 @@ export default class SvgDrawer {
             // Create a point on each side of the line
             sides = ArrayHelper.clone(normals);
 
-        if (this.opts.polymerDisplayMode === 'bracket-n' && (elementA === '*' || elementB === '*')) {
+        if (this.polymerOverlayState.enabled && (elementA === '*' || elementB === '*')) {
             return;
         }
 
@@ -421,7 +474,7 @@ export default class SvgDrawer {
         for (let i = 0; i < graph.vertices.length; i++) {
             let vertex = graph.vertices[i];
             let atom = vertex.value;
-            if (opts.polymerDisplayMode === 'bracket-n' && atom.element === '*') {
+            if (this.polymerOverlayState.enabled && atom.element === '*') {
                 continue;
             }
             let charge = 0;

--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -361,8 +361,13 @@ export default class SvgDrawer {
             let isCarbon = atom.element === 'C';
 
             if (opts.showAllCarbonLabels && element === 'C') {
-                isCarbon = false;
-                isTerminal = true;
+                const isRingCarbon = atom.rings && atom.rings.length > 0;
+                const shouldLabel = !(opts.showAllCarbonLabelsExcludeRings && isRingCarbon);
+
+                if (shouldLabel) {
+                    isCarbon = false;
+                    isTerminal = true;
+                }
             }
 
             // This is a HACK to remove all hydrogens from nitrogens in aromatic rings, as this

--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -72,6 +72,7 @@ export default class SvgDrawer {
         this.drawAtomHighlights(preprocessor.opts.debug);
         this.drawEdges(preprocessor.opts.debug);
         this.drawVertices(preprocessor.opts.debug);
+        this.drawPolymerRepeatOverlay();
 
         if (weights !== null) {
             this.drawWeights(weights, weightsNormalized);
@@ -94,6 +95,71 @@ export default class SvgDrawer {
         }
 
         return target;
+    }
+
+    /**
+     * Draw a polymer repeat-unit [ ]n overlay for wildcard endpoints (*).
+     * This is a display-only overlay and does not alter chemical graph semantics.
+     */
+    drawPolymerRepeatOverlay() {
+        if (this.opts.polymerDisplayMode !== 'bracket-n') {
+            return;
+        }
+
+        const vertices = this.preprocessor.graph.vertices.filter((vertex) => {
+            if (!vertex.value.isDrawn) return false;
+            if (vertex.value.element === '*') return false;
+            return true;
+        });
+
+        const wildcardCount = this.preprocessor.graph.vertices.filter((vertex) => vertex.value.element === '*').length;
+        if (wildcardCount < 2 || vertices.length < 2) {
+            return;
+        }
+
+        let minX = Number.MAX_VALUE;
+        let maxX = -Number.MAX_VALUE;
+        let minY = Number.MAX_VALUE;
+        let maxY = -Number.MAX_VALUE;
+
+        for (const vertex of vertices) {
+            minX = Math.min(minX, vertex.position.x);
+            maxX = Math.max(maxX, vertex.position.x);
+            minY = Math.min(minY, vertex.position.y);
+            maxY = Math.max(maxY, vertex.position.y);
+        }
+
+        // Use generous horizontal padding because text labels (e.g. H3C/CH3)
+        // extend beyond atom coordinates and would otherwise overlap brackets.
+        const labelPadding = this.opts.fontSizeLarge * 2.2;
+        const padX = this.opts.bondLength * 1.1 + labelPadding;
+        const padY = this.opts.bondLength * 0.5;
+        const leftX = minX - padX;
+        const rightX = maxX + padX;
+        const topY = minY - padY;
+        const bottomY = maxY + padY;
+        const arm = this.opts.bondLength * 0.35;
+
+        // Extend drawing bounds so brackets/text outside atom coordinates are not clipped.
+        this.svgWrapper.minX = Math.min(this.svgWrapper.minX, leftX - arm * 1.2);
+        this.svgWrapper.maxX = Math.max(this.svgWrapper.maxX, rightX + arm * 2.2);
+        this.svgWrapper.minY = Math.min(this.svgWrapper.minY, topY - arm * 0.8);
+        this.svgWrapper.maxY = Math.max(this.svgWrapper.maxY, bottomY + arm * 1.8);
+
+        const bracketLines = [
+            [new Vector2(leftX, topY), new Vector2(leftX + arm, topY)],
+            [new Vector2(leftX, topY), new Vector2(leftX, bottomY)],
+            [new Vector2(leftX, bottomY), new Vector2(leftX + arm, bottomY)],
+            [new Vector2(rightX - arm, topY), new Vector2(rightX, topY)],
+            [new Vector2(rightX, topY), new Vector2(rightX, bottomY)],
+            [new Vector2(rightX - arm, bottomY), new Vector2(rightX, bottomY)],
+        ];
+
+        for (const [start, end] of bracketLines) {
+            this.svgWrapper.drawLine(new Line(start, end, 'C', 'C'), false, null, 'square');
+        }
+
+        this.svgWrapper.drawAnnotationText(rightX + arm * 0.6, bottomY + arm * 0.9, 'n', 'start');
     }
 
     /**
@@ -199,6 +265,10 @@ export default class SvgDrawer {
             normals = preprocessor.getEdgeNormals(edge),
             // Create a point on each side of the line
             sides = ArrayHelper.clone(normals);
+
+        if (this.opts.polymerDisplayMode === 'bracket-n' && (elementA === '*' || elementB === '*')) {
+            return;
+        }
 
         sides[0].multiplyScalar(10).add(a);
         sides[1].multiplyScalar(10).add(a);
@@ -351,6 +421,9 @@ export default class SvgDrawer {
         for (let i = 0; i < graph.vertices.length; i++) {
             let vertex = graph.vertices[i];
             let atom = vertex.value;
+            if (opts.polymerDisplayMode === 'bracket-n' && atom.element === '*') {
+                continue;
+            }
             let charge = 0;
             let isotope = 0;
             let bondCount = vertex.value.bondCount;

--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -360,6 +360,11 @@ export default class SvgDrawer {
             let isTerminal = opts.terminalCarbons || element !== 'C' || atom.hasAttachedPseudoElements ? vertex.isTerminal() : false;
             let isCarbon = atom.element === 'C';
 
+            if (opts.showAllCarbonLabels && element === 'C') {
+                isCarbon = false;
+                isTerminal = true;
+            }
+
             // This is a HACK to remove all hydrogens from nitrogens in aromatic rings, as this
             // should be the most common state. This has to be fixed by kekulization
             if (atom.element === 'N' && atom.isPartOfAromaticRing) {

--- a/src/SvgWrapper.js
+++ b/src/SvgWrapper.js
@@ -470,6 +470,27 @@ export default class SvgWrapper {
     }
 
     /**
+     * Draws an annotation text in regular molecule color.
+     *
+     * @param {Number} x The x coordinate.
+     * @param {Number} y The y coordinate.
+     * @param {String} text The text to draw.
+     * @param {String} [anchor='middle'] Text anchor.
+     */
+    drawAnnotationText(x, y, text, anchor = 'middle') {
+        let textElem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        textElem.setAttributeNS(null, 'x', x);
+        textElem.setAttributeNS(null, 'y', y);
+        textElem.setAttributeNS(null, 'fill', this.themeManager.getColor('C'));
+        textElem.setAttributeNS(null, 'text-anchor', anchor);
+        textElem.setAttributeNS(null, 'style', `
+                font: ${this.opts.fontSizeLarge + 2}pt ${this.opts.fontFamily};
+            `);
+        textElem.appendChild(document.createTextNode(text));
+        this.vertices.push(textElem);
+    }
+
+    /**
      * Draws a ring.
      *
      * @param {x} x The x coordinate of the ring.

--- a/test/regression/rendering.test.js
+++ b/test/regression/rendering.test.js
@@ -33,6 +33,21 @@ function assertRendersToSVG(smiles) {
     expect(pp.graph.vertices.length).toBeGreaterThan(0);
 }
 
+function renderToSVG(smiles, options = {}) {
+    setupDOM();
+    const svg = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttributeNS(null, 'id', 'test-svg');
+    dom.window.document.body.appendChild(svg);
+
+    const tree = Parser.parse(smiles);
+    expect(tree).toBeDefined();
+
+    const drawer = new SvgDrawer({isomeric: true, ...options});
+    drawer.draw(tree, svg, 'light', false);
+
+    return svg;
+}
+
 // Basic structural motifs one representative per category
 describe('Rendering: structural motifs', () => {
     const cases = [
@@ -95,4 +110,21 @@ describe('Rendering: complex molecules', () => {
     for (const [name, smiles] of cases) {
         it(`${name}: ${smiles}`, () => assertRendersToSVG(smiles));
     }
+});
+
+describe('Rendering: polymer repeat overlay', () => {
+    it('draws [ ]n overlay for wildcard endpoints', () => {
+        const svg = renderToSVG('[*]CC(C(=O)OC)[*]', {polymerDisplayMode: 'bracket-n'});
+
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        expect(textValues).toContain('n');
+        expect(textValues.some((value) => value.includes('*'))).toBe(false);
+    });
+
+    it('keeps wildcard markers when overlay is disabled', () => {
+        const svg = renderToSVG('[*]CC(C(=O)OC)[*]', {polymerDisplayMode: 'none'});
+
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        expect(textValues.some((value) => value.includes('*'))).toBe(true);
+    });
 });

--- a/test/regression/rendering.test.js
+++ b/test/regression/rendering.test.js
@@ -127,4 +127,25 @@ describe('Rendering: polymer repeat overlay', () => {
         const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
         expect(textValues.some((value) => value.includes('*'))).toBe(true);
     });
+
+    it('does not apply overlay with a single wildcard endpoint', () => {
+        const svg = renderToSVG('[*]CC(C(=O)OC)', {polymerDisplayMode: 'bracket-n'});
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        expect(textValues).not.toContain('n');
+        expect(textValues.some((value) => value.includes('*'))).toBe(true);
+    });
+
+    it('does not apply overlay when wildcard is not terminal', () => {
+        const svg = renderToSVG('C[*]CC[*]', {polymerDisplayMode: 'bracket-n'});
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        expect(textValues).not.toContain('n');
+        expect(textValues.some((value) => value.includes('*'))).toBe(true);
+    });
+
+    it('does not apply overlay when there are more than two wildcards', () => {
+        const svg = renderToSVG('[*]C([*])C[*]', {polymerDisplayMode: 'bracket-n'});
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        expect(textValues).not.toContain('n');
+        expect(textValues.some((value) => value.includes('*'))).toBe(true);
+    });
 });


### PR DESCRIPTION
## Why

Wildcard endpoints (`*`) are useful for polymer repeat units in SMILES, but they are not ideal for human-facing display.  
This PR adds an optional display mode to render a repeat-unit style overlay (`[ ]n`) while preserving the underlying chemical graph semantics.

## What

- Add a new option: `polymerDisplayMode` (`'none' | 'bracket-n'`, default: `'none'`)
- In `'bracket-n'` mode:
  - draw a display-only `[ ]n` overlay around wildcard-repeat structures
  - hide wildcard (`*`) endpoint markers in the rendered output
- Keep behavior opt-in and backward-compatible (default unchanged)
- Update README:
  - options table
  - default options snippet
  - behavior note
- Added regression tests for polymer overlay behavior:
  - overlay mode shows `n` and suppresses `*`
  - non-overlay mode keeps `*` markers

## Backward compatibility

No breaking change.  
Default remains `polymerDisplayMode: 'none'`.

## Validation

- `npm run build`
- `npm run test:unit` (including regression tests)