### PR TITLE
Fix Hydrogen Counting

### DIFF
--- a/src/Atom.js
+++ b/src/Atom.js
@@ -262,6 +262,36 @@ export default class Atom {
     }
 
     /**
+     * Counts the implicit hydrogens attached to this atom.
+     *
+     * This function deals with hydrogens specified in SMILES brackets
+     * and inferred based on bond counts and normal valences (see the
+     * VALENCES constant below).  It does NOT count any hydrogens that
+     * are attached as separate atoms in the SMILES string ([H]Cl).
+     *
+     * @returns {number} The number of implicit hydrogens attached to this atom.
+     */
+    countHydrogens() {
+        if (this.bracket) {
+            return this.bracket.hcount || 0;
+        }
+
+        let bonds = this.bondCount;
+        if (this.isPartOfAromaticRing) {
+            // TODO: This is definitely a hacky workaround for something...
+            // Figure out what and fix the real issue!
+            bonds += 1;
+        }
+
+        const valences = Atom.VALENCES[this.element];
+        const valence  = valences.find(n => (n >= bonds));
+
+        if (valence !== undefined) {
+            return valence - bonds;
+        }
+    }
+
+    /**
      * A map mapping element symbols to their maximum bonds.
      */
     static get maxBonds() {
@@ -279,6 +309,22 @@ export default class Atom {
             Br: 1,
         };
     }
+
+    // Possible valences according to OpenSMILES
+    // http://opensmiles.org/opensmiles.html#orgsbst
+    static VALENCES = {
+        H:  [1],
+        B:  [3],
+        C:  [4],
+        N:  [3, 5],
+        O:  [2],
+        F:  [1],
+        P:  [3, 5],
+        S:  [2, 4, 6],
+        Cl: [1],
+        Br: [1],
+        I:  [1],
+    };
 
     /**
      * A map mapping element symbols to the atomic number.

--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -517,40 +517,13 @@ export default class DrawerBase {
         for (let i = 0; i < graph.vertices.length; i++) {
             let atom = graph.vertices[i].value;
 
-            if (counts.has(atom.element)) {
-                counts.set(atom.element, counts.get(atom.element) + 1);
-            }
-            else {
-                counts.set(atom.element, 1);
-            }
+            const a = counts.get(atom.element) || 0;
+            counts.set(atom.element, a + 1);
 
-            // Hydrogens attached to a chiral center were added as vertices,
-            // those in non chiral brackets are added here
-            if (atom.bracket && !atom.bracket.chirality) {
-                if (counts.has('H')) {
-                    counts.set('H', counts.get('H') + atom.bracket.hcount);
-                }
-                else {
-                    counts.set('H', atom.bracket.hcount);
-                }
-            }
-
-            // Add the implicit hydrogens according to valency, exclude
-            // bracket atoms as they were handled and always have the number
-            // of hydrogens specified explicitly
-            if (!atom.bracket) {
-                let nHydrogens = Atom.maxBonds[atom.element] - atom.bondCount;
-
-                if (atom.isPartOfAromaticRing) {
-                    nHydrogens--;
-                }
-
-                if (counts.has('H')) {
-                    counts.set('H', counts.get('H') + nHydrogens);
-                }
-                else {
-                    counts.set('H', nHydrogens);
-                }
+            const hydrogens = atom.countHydrogens();
+            if (hydrogens) {
+                const h = counts.get('H') || 0;
+                counts.set('H', h + hydrogens);
             }
         }
 
@@ -1791,9 +1764,8 @@ export default class DrawerBase {
             let atom = vertex.value;
             let charge = 0;
             let isotope = 0;
-            let bondCount = vertex.value.bondCount;
             let element = atom.element;
-            let hydrogens = Atom.maxBonds[element] - bondCount;
+            let hydrogens = atom.countHydrogens();
             let dir = vertex.getTextDirection(this.graph.vertices);
             let isTerminal = this.opts.terminalCarbons || element !== 'C' || atom.hasAttachedPseudoElements ? vertex.isTerminal() : false;
             let isCarbon = atom.element === 'C';
@@ -3611,13 +3583,8 @@ export default class DrawerBase {
 
         // Valences are filled with hydrogens and passed to the next level.
         if (depth < maxDepth - 1) {
-            let bonds = 0;
-
-            for (let i = 0; i < neighbours.length; i++) {
-                bonds += this.graph.getEdge(vertexId, neighbours[i]).weight;
-            }
-
-            for (let i = 0; i < vertex.value.getMaxBonds() - bonds; i++) {
+            const hydrogens = vertex.value.countHydrogens();
+            for (let i = 0; i < hydrogens; i++) {
                 if (priority.length <= depth + 1) {
                     priority.push([]);
                 }
@@ -3701,11 +3668,7 @@ export default class DrawerBase {
         }
 
         // Implicit hydrogens
-        let bonds = 0;
-        for (let i = 0; i < neighbours.length; i++) {
-            bonds += this.graph.getEdge(vertexId, neighbours[i]).weight;
-        }
-        let implicitH = vertex.value.getMaxBonds() - bonds;
+        const implicitH = vertex.value.countHydrogens();
         for (let i = 0; i < implicitH; i++) {
             node.children.push({an: 1, children: [], hasStereo: false});
         }
@@ -3851,11 +3814,11 @@ export default class DrawerBase {
 
                 neighbour.value.isDrawn = false;
 
-                let hydrogens = Atom.maxBonds[neighbour.value.element] - neighbour.value.bondCount;
+                let hydrogens = neighbour.value.countHydrogens();
+                console.log(neighbour.value.element, hydrogens);
                 let charge = '';
 
                 if (neighbour.value.bracket) {
-                    hydrogens = neighbour.value.bracket.hcount;
                     charge = neighbour.value.bracket.charge || 0;
                 }
 

--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -353,9 +353,8 @@ export default class SvgDrawer {
             let atom = vertex.value;
             let charge = 0;
             let isotope = 0;
-            let bondCount = vertex.value.bondCount;
             let element = atom.element;
-            let hydrogens = Atom.maxBonds[element] - bondCount;
+            let hydrogens = atom.countHydrogens();
             let dir = vertex.getTextDirection(graph.vertices, atom.hasAttachedPseudoElements);
             let isTerminal = opts.terminalCarbons || element !== 'C' || atom.hasAttachedPseudoElements ? vertex.isTerminal() : false;
             let isCarbon = atom.element === 'C';


### PR DESCRIPTION
This is a partial fix for #262 - it fixes the chemical formulas shown in reactions, but the compact mode drawing is still missing an H.  I may add a fix for that to this PR if I can find it quickly, but this can also be merged as-is.

The bug (showing sulphuric acid as HO₄S instead of H₂O₄S) was fairly complex:
- First, the algorithm for counting implicit hydrogens used too simple a formula: `maxBonds - bonds`.  But some atoms have multiple "happy" numbers of bonds.  In this case, sulphur had `maxBonds` set to 2, but it can actually have 2, 4, or 6.  So it's contribution to the number of hydrogens was negative four!  Add two from the two OH groups, and the molecule as a whole had -2 hydrogens.
- Then the formula generator appends all elements with a non-zero count to the formula string.  All elements with a count greater than one are appended as E#, and the rest are appended as simply E.  Negative two isn't zero, so hydrogen was added, and it isn't greater than one, so it was added as simply H.