### PR TITLE
JSDOM Helper

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,23 @@
+import {JSDOM} from 'jsdom';
+
+export function createJSDOM(options) {
+    options ||= {};
+
+    const dom = new JSDOM(options.html || '<!DOCTYPE html><html><body></body></html>');
+    global.document = dom.window.document;
+    global.window   = dom.window;
+
+    if (options.patchCanvasGetContext !== false) {
+        // Suppress the bajillion copies of this warning message that get written to stderr:
+        // Not implemented: HTMLCanvasElement's getContext() method: without installing the canvas npm package
+        const proto    = dom.window.HTMLCanvasElement.prototype;
+        const original = proto.getContext;
+
+        proto.getContext = () => null;
+        proto.restoreGetContext = () => {
+            proto.getContext = original;
+        };
+    }
+
+    return dom;
+}

--- a/test/regression/bridged-layout.test.js
+++ b/test/regression/bridged-layout.test.js
@@ -1,16 +1,9 @@
 import {describe, it, expect} from 'vitest';
-import {JSDOM} from 'jsdom';
-import Parser from '../../src/Parser.js';
+import {createJSDOM}          from '../helpers';
+
+import Parser    from '../../src/Parser.js';
 import SvgDrawer from '../../src/SvgDrawer.js';
-import Vector2 from '../../src/Vector2.js';
-
-function setupDOM() {
-    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
-    global.document = dom.window.document;
-    global.window = dom.window;
-
-    return dom;
-}
+import Vector2   from '../../src/Vector2.js';
 
 function averagePosition(vertices) {
     let center = new Vector2(0, 0);
@@ -23,7 +16,8 @@ function averagePosition(vertices) {
 }
 
 function expectBridgeAtomInside(smiles) {
-    const dom = setupDOM();
+    const dom = createJSDOM();
+
     const svg = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     dom.window.document.body.appendChild(svg);
 

--- a/test/regression/ez-stereo.test.js
+++ b/test/regression/ez-stereo.test.js
@@ -10,17 +10,18 @@
  *     - opposite signs = opposite sides = E (trans)
  */
 import {describe, it, expect} from 'vitest';
-import {JSDOM} from 'jsdom';
-import Parser from '../../src/Parser.js';
+import {createJSDOM}          from '../helpers';
+
+import Parser    from '../../src/Parser.js';
 import SvgDrawer from '../../src/SvgDrawer.js';
 
 function render(smiles) {
-    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
-    global.document = dom.window.document;
-    global.window = dom.window;
+    const dom = createJSDOM();
+
     const svg = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.setAttributeNS(null, 'id', 'test-svg');
     dom.window.document.body.appendChild(svg);
+
     const tree = Parser.parse(smiles);
     const drawer = new SvgDrawer({isomeric: true});
     drawer.draw(tree, svg, 'light', false);

--- a/test/regression/rendering.test.js
+++ b/test/regression/rendering.test.js
@@ -6,19 +6,14 @@
  * If a new bug is found, SMILES cna be added here before fixing it.
  */
 import {describe, it, expect} from 'vitest';
-import {JSDOM} from 'jsdom';
-import Parser from '../../src/Parser.js';
+import {createJSDOM}          from '../helpers';
+
+import Parser    from '../../src/Parser.js';
 import SvgDrawer from '../../src/SvgDrawer.js';
 
-let dom;
-function setupDOM() {
-    dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
-    global.document = dom.window.document;
-    global.window = dom.window;
-}
-
 function assertRendersToSVG(smiles) {
-    setupDOM();
+    const dom = createJSDOM();
+
     const svg = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.setAttributeNS(null, 'id', 'test-svg');
     dom.window.document.body.appendChild(svg);

--- a/test/stereo-reference/stereo-inversion-baseline.test.js
+++ b/test/stereo-reference/stereo-inversion-baseline.test.js
@@ -1,13 +1,10 @@
 import {describe, it, expect} from 'vitest';
-import {JSDOM} from 'jsdom';
-import {readFileSync} from 'fs';
-import {join, dirname} from 'path';
-import {fileURLToPath} from 'url';
-import Parser from '../../src/Parser.js';
+import {createJSDOM}          from '../helpers';
+
+import Parser    from '../../src/Parser.js';
 import SvgDrawer from '../../src/SvgDrawer.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const reference = JSON.parse(readFileSync(join(__dirname, 'reference.json'), 'utf-8'));
+import reference from './reference.json' with {type: 'json'};
 
 const INVERSION_BASELINE_IDS = [
     'Codeine:v19',
@@ -24,9 +21,7 @@ function subtractSorted(a, b) {
 }
 
 function render(smiles) {
-    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
-    global.document = dom.window.document;
-    global.window = dom.window;
+    const dom = createJSDOM();
 
     const svg = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.setAttributeNS(null, 'id', 'test-svg');

--- a/test/stereo-reference/stereo-vs-rdkit.test.js
+++ b/test/stereo-reference/stereo-vs-rdkit.test.js
@@ -12,20 +12,15 @@
  * Run:  npm test -- test/stereo-reference/stereo-vs-rdkit.test.js
  */
 import {describe, it, expect} from 'vitest';
-import {JSDOM} from 'jsdom';
-import {readFileSync} from 'fs';
-import {join, dirname} from 'path';
-import {fileURLToPath} from 'url';
-import Parser from '../../src/Parser.js';
+import {createJSDOM}          from '../helpers';
+
+import Parser    from '../../src/Parser.js';
 import SvgDrawer from '../../src/SvgDrawer.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const reference = JSON.parse(readFileSync(join(__dirname, 'reference.json'), 'utf-8'));
+import reference from './reference.json' with {type: 'json'};
 
 function renderAndGetStereo(smiles) {
-    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
-    global.document = dom.window.document;
-    global.window = dom.window;
+    const dom = createJSDOM();
 
     const svg = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.setAttributeNS(null, 'id', 'test-svg');

--- a/test/unit/SvgWrapper.test.js
+++ b/test/unit/SvgWrapper.test.js
@@ -1,38 +1,13 @@
 import {afterEach, describe, expect, it} from 'vitest';
-import {JSDOM} from 'jsdom';
-import Parser from '../../src/Parser.js';
-import SvgDrawer from '../../src/SvgDrawer.js';
+import {createJSDOM}                     from '../helpers';
+
+import Parser     from '../../src/Parser.js';
+import SvgDrawer  from '../../src/SvgDrawer.js';
 import SvgWrapper from '../../src/SvgWrapper.js';
-
-let restoreGetContext = null;
-
-function setupDom() {
-    const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
-    global.document = dom.window.document;
-    global.window = dom.window;
-    return dom;
-}
-
-function disableCanvasContext(dom) {
-    const proto = dom.window.HTMLCanvasElement.prototype;
-    const original = proto.getContext;
-    proto.getContext = () => null;
-    restoreGetContext = () => {
-        proto.getContext = original;
-    };
-}
-
-afterEach(() => {
-    if (restoreGetContext) {
-        restoreGetContext();
-        restoreGetContext = null;
-    }
-});
 
 describe('SvgWrapper', () => {
     it('falls back to estimated text size when canvas is unavailable', () => {
-        const dom = setupDom();
-        disableCanvasContext(dom);
+        const dom = createJSDOM();
 
         const dims = SvgWrapper.measureText('CH3', 11, 'Helvetica');
 
@@ -41,8 +16,7 @@ describe('SvgWrapper', () => {
     });
 
     it('renders SVG without canvas text metrics support', () => {
-        const dom = setupDom();
-        disableCanvasContext(dom);
+        const dom = createJSDOM();
 
         const svg = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
         svg.setAttributeNS(null, 'id', 'test-svg');


### PR DESCRIPTION
This adds a single `createJSDOM()` helper function and updates the tests that use the DOM to use it.  This function also silences the warning message that was showing up way too often in the logs:

> Not implemented: HTMLCanvasElement's getContext() method: without installing the canvas npm package

(It also tweaks the JSON loading in the stereo tests to use `import` so we're not so closely tied to Node.js.)