### PR TITLE
Simplify and color code debug labels.

### DIFF
--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -309,7 +309,7 @@ export default class SvgDrawer {
 
         if (debug) {
             let midpoint = Vector2.midpoint(a, b);
-            svgWrapper.drawDebugText(midpoint.x, midpoint.y, 'e: ' + edgeId);
+            svgWrapper.drawDebugText(midpoint.x, midpoint.y, 'e' + edgeId, '#0c0');
         }
     }
 
@@ -409,19 +409,16 @@ export default class SvgDrawer {
             }
 
             if (debug) {
-                let value = 'v: ' + vertex.id + ' ' + ArrayHelper.print(atom.ringbonds);
+                const value = 'v' + vertex.id + ' ' + ArrayHelper.print(atom.ringbonds);
                 svgWrapper.drawDebugText(vertex.position.x, vertex.position.y, value);
             }
-            // else {
-            //   svgWrapper.drawDebugText(vertex.position.x, vertex.position.y, vertex.value.chirality);
-            // }
         }
 
         // Draw the ring centers for debug purposes
         if (opts.debug) {
             for (let i = 0; i < rings.length; i++) {
                 let center = rings[i].center;
-                svgWrapper.drawDebugPoint(center.x, center.y, 'r: ' + rings[i].id);
+                svgWrapper.drawDebugPoint(center.x, center.y, 'r' + rings[i].id, '#00f');
             }
         }
     }

--- a/src/SvgWrapper.js
+++ b/src/SvgWrapper.js
@@ -445,7 +445,7 @@ export default class SvgWrapper {
         point.setAttributeNS(null, 'r', '2');
         point.setAttributeNS(null, 'fill', color);
         this.vertices.push(point);
-        this.drawDebugText(x, y, debugText);
+        this.drawDebugText(x + 2, y - 2, debugText, color);
     }
 
     /**
@@ -455,15 +455,13 @@ export default class SvgWrapper {
      * @param {Number} y The y coordinate.
      * @param {String} text The debug text.
      */
-    drawDebugText(x, y, text) {
+    drawDebugText(x, y, text, color = '#f00') {
         let textElem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
         textElem.setAttributeNS(null, 'x', x);
         textElem.setAttributeNS(null, 'y', y);
         textElem.setAttributeNS(null, 'class', 'debug');
-        textElem.setAttributeNS(null, 'fill', '#ff0000');
-        textElem.setAttributeNS(null, 'style', `
-                font: 5px Droid Sans, sans-serif;
-            `);
+        textElem.setAttributeNS(null, 'fill', color);
+        textElem.setAttributeNS(null, 'style', 'font: 5px sans-serif');
         textElem.appendChild(document.createTextNode(text));
 
         this.vertices.push(textElem);


### PR DESCRIPTION
This simplifies the debug labels and changes them from being all red to being red, green, and blue for vertices, edges, and rings.  It made my life a little easier while I was hunting down stereochemistry bugs for #273.