### PR TITLE
feat(polymer): add repeat-unit bracket notation for terminal wildcard polymers

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The following options are available:
 | Use experimental SSSR                                           | experimentalSSSR            | boolean                             | false         |
 | Show explicit carbons                                           | showCarbons                 | string ['none', 'default', 'terminal', 'acyclic', 'all'] | 'default'     |
 | Show terminal carbons (deprecated; use `showCarbons`)           | terminalCarbons             | boolean                             | false         |
+| Polymer repeat-unit rendering style for wildcard endpoints      | polymerRepeatUnitStyle      | string ['none', 'bracket-n']        | 'none'        |
 | Show explicit hydrogens                                         | explicitHydrogens           | boolean                             | true          |
 | Overlap sensitivity                                             | overlapSensitivity          | number                              | 0.42          |
 | # of overlap resolution iterations                              | overlapResolutionIterations | number                              | 1             |
@@ -217,6 +218,7 @@ The default options are defined as follows:
     debug: false,
     showCarbons: 'default',
     terminalCarbons: false,
+    polymerRepeatUnitStyle: 'none',
     explicitHydrogens: true,
     overlapSensitivity: 0.42,
     overlapResolutionIterations: 1,
@@ -271,6 +273,8 @@ Additional built-in themes include `oldschool`, `solarized`, and `solarized-dark
 - `"all"` labels every carbon, including ring atoms.
 
 If `showCarbons` is `"default"` and `terminalCarbons` is `true`, the effective mode is `"terminal"` (legacy compatibility until v3.0).
+
+`polymerRepeatUnitStyle: 'bracket-n'` enables a display-only polymer repeat notation for strict repeat-endpoint patterns (exactly two wildcard `*` atoms, each terminal, SMILES starting with `*` on the parse-tree root, and ending the main chain with `*`). It draws `[ ]n`, hides wildcard labels, and adds decorative continuation stubs across the brackets. Other wildcard usages keep default rendering.
 
 
 ### Usage

--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -55,6 +55,7 @@ export default class DrawerBase {
             debug:                       false,
             terminalCarbons:             false,
             showCarbons:                 'default',
+            polymerRepeatUnitStyle:      'none',
             explicitHydrogens:           true,
             overlapSensitivity:          0.42,
             overlapResolutionIterations: 1,
@@ -292,6 +293,10 @@ export default class DrawerBase {
         const allowedShowCarbons = ['none', 'default', 'terminal', 'acyclic', 'all'];
         if (allowedShowCarbons.indexOf(this.opts.showCarbons) === -1) {
             this.opts.showCarbons = 'default';
+        }
+        const allowedPolymerRepeatUnitStyles = ['none', 'bracket-n'];
+        if (allowedPolymerRepeatUnitStyles.indexOf(this.opts.polymerRepeatUnitStyle) === -1) {
+            this.opts.polymerRepeatUnitStyle = 'none';
         }
 
         this.opts.halfBondSpacing = this.opts.bondSpacing / 2.0;

--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -6,6 +6,7 @@ import Atom         from './Atom';
 import DrawerBase   from './DrawerBase';
 import GaussDrawer  from './GaussDrawer';
 import Line         from './Line';
+import {computePolymerRepeatUnitOverlayState, drawPolymerRepeatUnitOverlay} from './polymerRepeatUnitOverlay';
 import Ring         from './Ring';
 import SvgWrapper   from './SvgWrapper';
 import ThemeManager from './ThemeManager';
@@ -17,6 +18,10 @@ export default class SvgDrawer {
         this.opts = this.preprocessor.opts;
         this.clear = clear;
         this.svgWrapper = null;
+        this.polymerOverlayState = {
+            enabled: false,
+            wildcardVertexIds: new Set(),
+        };
     }
 
     /**
@@ -67,11 +72,13 @@ export default class SvgDrawer {
 
         // Set the canvas to the appropriate size
         this.svgWrapper.determineDimensions(preprocessor.graph.vertices);
+        this.polymerOverlayState = this.getPolymerOverlayState();
 
         // Do the actual drawing
         this.drawAtomHighlights(preprocessor.opts.debug);
         this.drawEdges(preprocessor.opts.debug);
         this.drawVertices(preprocessor.opts.debug);
+        this.drawPolymerRepeatOverlay();
 
         if (weights !== null) {
             this.drawWeights(weights, weightsNormalized);
@@ -94,6 +101,22 @@ export default class SvgDrawer {
         }
 
         return target;
+    }
+
+    /**
+     * Return whether polymer overlay should be enabled and which wildcard vertices are involved.
+     * @see computePolymerRepeatUnitOverlayState in ./polymerRepeatUnitOverlay.js
+     */
+    getPolymerOverlayState() {
+        return computePolymerRepeatUnitOverlayState(this.preprocessor.graph, this.opts);
+    }
+
+    /**
+     * Draw a polymer repeat-unit [ ]n overlay for wildcard endpoints (*).
+     * @see drawPolymerRepeatUnitOverlay in ./polymerRepeatUnitOverlay.js
+     */
+    drawPolymerRepeatOverlay() {
+        drawPolymerRepeatUnitOverlay(this.svgWrapper, this.preprocessor.graph, this.polymerOverlayState, this.opts);
     }
 
     /**
@@ -201,6 +224,10 @@ export default class SvgDrawer {
             normals = preprocessor.getEdgeNormals(edge),
             // Create a point on each side of the line
             sides = ArrayHelper.clone(normals);
+
+        if (this.polymerOverlayState.enabled && (elementA === '*' || elementB === '*')) {
+            return;
+        }
 
         sides[0].multiplyScalar(10).add(a);
         sides[1].multiplyScalar(10).add(a);
@@ -345,6 +372,9 @@ export default class SvgDrawer {
         for (let i = 0; i < graph.vertices.length; i++) {
             let vertex = graph.vertices[i];
             let atom = vertex.value;
+            if (this.polymerOverlayState.enabled && atom.element === '*') {
+                continue;
+            }
             let charge = 0;
             let isotope = 0;
             let element = atom.element;

--- a/src/SvgWrapper.js
+++ b/src/SvgWrapper.js
@@ -538,6 +538,27 @@ export default class SvgWrapper {
     }
 
     /**
+     * Draws annotation text in regular molecule color.
+     *
+     * @param {Number} x The x coordinate.
+     * @param {Number} y The y coordinate.
+     * @param {String} text The text to draw.
+     * @param {String} [anchor='middle'] Text anchor.
+     */
+    drawAnnotationText(x, y, text, anchor = 'middle') {
+        let textElem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        textElem.setAttributeNS(null, 'x', x);
+        textElem.setAttributeNS(null, 'y', y);
+        textElem.setAttributeNS(null, 'fill', this.themeManager.getColor('C'));
+        textElem.setAttributeNS(null, 'text-anchor', anchor);
+        textElem.setAttributeNS(null, 'style', `
+                font: ${this.opts.fontSizeLarge + 2}pt ${this.opts.fontFamily};
+            `);
+        textElem.appendChild(document.createTextNode(text));
+        this.vertices.push(textElem);
+    }
+
+    /**
      * Draws a ring.
      *
      * @param {x} x The x coordinate of the ring.

--- a/src/polymerRepeatUnitOverlay.js
+++ b/src/polymerRepeatUnitOverlay.js
@@ -1,0 +1,137 @@
+// @ts-check
+import Line    from './Line';
+import Vector2 from './Vector2';
+
+/**
+ * @typedef {{ enabled: boolean, wildcardVertexIds: Set<number> }} PolymerRepeatUnitOverlayState
+ */
+
+/**
+ * Decide whether the strict repeat-endpoint `bracket-n` overlay applies, and which wildcard vertices it hides.
+ * Pure function: no SVG or theme side effects.
+ *
+ * @param {{ vertices: Array<{ id: number, value: object, neighbours: number[], parentVertexId: number|null, children: number[], getNeighbourCount: () => number }> }} graph
+ * @param {{ polymerRepeatUnitStyle?: string }} opts
+ * @returns {PolymerBracketOverlayState}
+ */
+export function computePolymerRepeatUnitOverlayState(graph, opts) {
+    const empty = () => ({enabled: false, wildcardVertexIds: new Set()});
+
+    if (opts.polymerRepeatUnitStyle !== 'bracket-n') {
+        return empty();
+    }
+
+    const wildcardVertices = graph.vertices.filter((vertex) => vertex.value.element === '*');
+    if (wildcardVertices.length !== 2) {
+        return empty();
+    }
+
+    // Require SMILES to start with * and end the main chain with * (polymer repeat syntax).
+    // Do not use global min/max of smilesOrder: that field is branch-local in Graph._init and
+    // fails for e.g. *CC(=O)O* where a branch O has a higher order than the tail *.
+    const rootWildcards = wildcardVertices.filter((vertex) => vertex.parentVertexId === null);
+    const tailWildcards = wildcardVertices.filter((vertex) => vertex.children.length === 0);
+    if (rootWildcards.length !== 1 || tailWildcards.length !== 1) {
+        return empty();
+    }
+    if (rootWildcards[0].id === tailWildcards[0].id) {
+        return empty();
+    }
+
+    const wildcardIds = new Set(wildcardVertices.map((vertex) => vertex.id));
+
+    for (const wildcard of wildcardVertices) {
+        if (wildcard.getNeighbourCount() !== 1) {
+            return empty();
+        }
+
+        if (wildcard.value.rings && wildcard.value.rings.length > 0) {
+            return empty();
+        }
+
+        const attachedId = wildcard.neighbours[0];
+        const attached = graph.vertices[attachedId];
+        if (!attached || attached.value.element === '*') {
+            return empty();
+        }
+    }
+
+    return {enabled: true, wildcardVertexIds: wildcardIds};
+}
+
+/**
+ * Draw display-only `[ ]n` brackets and repeat count `n` when overlay state is enabled.
+ *
+ * @param {*} svgWrapper SvgWrapper instance (mutates min/max bounds, pushes SVG primitives).
+ * @param {{ vertices: Array<{ value: { isDrawn?: boolean }, position: { x: number, y: number }, id: number }> }} graph
+ * @param {PolymerRepeatUnitOverlayState} state
+ * @param {{ bondLength: number, fontSizeLarge: number }} opts
+ */
+export function drawPolymerRepeatUnitOverlay(svgWrapper, graph, state, opts) {
+    if (!state.enabled) {
+        return;
+    }
+
+    const vertices = graph.vertices.filter((vertex) => {
+        if (!vertex.value.isDrawn) return false;
+        if (state.wildcardVertexIds.has(vertex.id)) return false;
+        return true;
+    });
+    if (vertices.length < 2) {
+        return;
+    }
+
+    let minX = Number.MAX_VALUE;
+    let maxX = -Number.MAX_VALUE;
+    let minY = Number.MAX_VALUE;
+    let maxY = -Number.MAX_VALUE;
+
+    for (const vertex of vertices) {
+        minX = Math.min(minX, vertex.position.x);
+        maxX = Math.max(maxX, vertex.position.x);
+        minY = Math.min(minY, vertex.position.y);
+        maxY = Math.max(maxY, vertex.position.y);
+    }
+
+    const labelPadding = opts.fontSizeLarge * 2.2;
+    const padX = opts.bondLength * 1.1 + labelPadding;
+    const padY = opts.bondLength * 0.5;
+    const leftX = minX - padX;
+    const rightX = maxX + padX;
+    const topY = minY - padY;
+    const bottomY = maxY + padY;
+    const arm = opts.bondLength * 0.35;
+
+    const stubLength = opts.bondLength * 0.4;
+    const crossInset = opts.bondLength * 0.2;
+    const stubReach = stubLength + crossInset;
+    svgWrapper.minX = Math.min(svgWrapper.minX, leftX - stubReach - arm * 0.8);
+    // Keep extra room on the right for both stub and trailing "n" label.
+    svgWrapper.maxX = Math.max(svgWrapper.maxX, rightX + stubReach + arm * 2.2);
+    svgWrapper.minY = Math.min(svgWrapper.minY, topY - arm * 0.8);
+    svgWrapper.maxY = Math.max(svgWrapper.maxY, bottomY + arm * 1.8);
+
+    const bracketLines = [
+        [new Vector2(leftX, topY), new Vector2(leftX + arm, topY)],
+        [new Vector2(leftX, topY), new Vector2(leftX, bottomY)],
+        [new Vector2(leftX, bottomY), new Vector2(leftX + arm, bottomY)],
+        [new Vector2(rightX - arm, topY), new Vector2(rightX, topY)],
+        [new Vector2(rightX, topY), new Vector2(rightX, bottomY)],
+        [new Vector2(rightX - arm, bottomY), new Vector2(rightX, bottomY)],
+    ];
+
+    for (const [start, end] of bracketLines) {
+        svgWrapper.drawLine(new Line(start, end, 'C', 'C'), false, svgWrapper.themeManager.getColor('C'), 'square');
+    }
+
+    // Draw decorative continuation stubs across brackets to indicate repeat continuation.
+    const centerY = (topY + bottomY) / 2.0;
+    const leftStubStart = new Vector2(leftX + crossInset, centerY);
+    const leftStubEnd = new Vector2(leftX - stubLength, centerY);
+    const rightStubStart = new Vector2(rightX - crossInset, centerY);
+    const rightStubEnd = new Vector2(rightX + stubLength, centerY);
+    svgWrapper.drawLine(new Line(leftStubStart, leftStubEnd, 'C', 'C'), false, svgWrapper.themeManager.getColor('C'), 'square');
+    svgWrapper.drawLine(new Line(rightStubStart, rightStubEnd, 'C', 'C'), false, svgWrapper.themeManager.getColor('C'), 'square');
+
+    svgWrapper.drawAnnotationText(rightX + arm * 0.6, bottomY + arm * 0.9, 'n', 'start');
+}

--- a/test/regression/rendering.test.js
+++ b/test/regression/rendering.test.js
@@ -28,6 +28,22 @@ function assertRendersToSVG(smiles) {
     expect(pp.graph.vertices.length).toBeGreaterThan(0);
 }
 
+function renderToSVG(smiles, options = {}) {
+    const dom = createJSDOM();
+
+    const svg = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttributeNS(null, 'id', 'test-svg');
+    dom.window.document.body.appendChild(svg);
+
+    const tree = Parser.parse(smiles);
+    expect(tree).toBeDefined();
+
+    const drawer = new SvgDrawer({isomeric: true, ...options});
+    drawer.draw(tree, svg, 'light', false);
+
+    return svg;
+}
+
 // Basic structural motifs one representative per category
 describe('Rendering: structural motifs', () => {
     const cases = [
@@ -90,4 +106,51 @@ describe('Rendering: complex molecules', () => {
     for (const [name, smiles] of cases) {
         it(`${name}: ${smiles}`, () => assertRendersToSVG(smiles));
     }
+});
+
+describe('Rendering: polymer repeat overlay', () => {
+    it('draws [ ]n overlay for wildcard endpoints', () => {
+        const svg = renderToSVG('[*]CC(C(=O)OC)[*]', {polymerRepeatUnitStyle: 'bracket-n'});
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        const squareLines = svg.querySelectorAll('line[stroke-linecap=\"square\"]');
+        expect(textValues).toContain('n');
+        expect(textValues.some((value) => value.includes('*'))).toBe(false);
+        expect(squareLines.length).toBe(8);
+    });
+
+    it('draws [ ]n for *CC(=O)O* (tail * must not rely on smilesOrder max)', () => {
+        const svg = renderToSVG('*CC(=O)O*', {polymerRepeatUnitStyle: 'bracket-n'});
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        const squareLines = svg.querySelectorAll('line[stroke-linecap=\"square\"]');
+        expect(textValues).toContain('n');
+        expect(textValues.some((value) => value.includes('*'))).toBe(false);
+        expect(squareLines.length).toBe(8);
+    });
+
+    it('keeps wildcard markers when overlay is disabled', () => {
+        const svg = renderToSVG('[*]CC(C(=O)OC)[*]', {polymerRepeatUnitStyle: 'none'});
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        expect(textValues.some((value) => value.includes('*'))).toBe(true);
+    });
+
+    it('does not apply overlay with a single wildcard endpoint', () => {
+        const svg = renderToSVG('[*]CC(C(=O)OC)', {polymerRepeatUnitStyle: 'bracket-n'});
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        expect(textValues).not.toContain('n');
+        expect(textValues.some((value) => value.includes('*'))).toBe(true);
+    });
+
+    it('does not apply overlay when wildcard is not terminal', () => {
+        const svg = renderToSVG('C[*]CC[*]', {polymerRepeatUnitStyle: 'bracket-n'});
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        expect(textValues).not.toContain('n');
+        expect(textValues.some((value) => value.includes('*'))).toBe(true);
+    });
+
+    it('does not apply overlay when there are more than two wildcards', () => {
+        const svg = renderToSVG('[*]C([*])C[*]', {polymerRepeatUnitStyle: 'bracket-n'});
+        const textValues = Array.from(svg.querySelectorAll('text')).map((el) => el.textContent || '');
+        expect(textValues).not.toContain('n');
+        expect(textValues.some((value) => value.includes('*'))).toBe(true);
+    });
 });

--- a/test/unit/polymerRepeatUnitOverlay.test.js
+++ b/test/unit/polymerRepeatUnitOverlay.test.js
@@ -1,0 +1,17 @@
+import {describe, expect, it} from 'vitest';
+import {computePolymerRepeatUnitOverlayState} from '../../src/polymerRepeatUnitOverlay.js';
+
+describe('polymerRepeatUnitOverlay', () => {
+    describe('computePolymerRepeatUnitOverlayState', () => {
+        it('returns disabled when polymerRepeatUnitStyle is not bracket-n', () => {
+            const state = computePolymerRepeatUnitOverlayState({vertices: []}, {polymerRepeatUnitStyle: 'none'});
+            expect(state.enabled).toBe(false);
+            expect(state.wildcardVertexIds.size).toBe(0);
+        });
+
+        it('returns disabled when mode is bracket-n but there are no wildcard endpoints', () => {
+            const state = computePolymerRepeatUnitOverlayState({vertices: []}, {polymerRepeatUnitStyle: 'bracket-n'});
+            expect(state.enabled).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

This PR adds an opt-in polymer repeat-unit rendering mode:

- New option: `polymerRepeatUnitStyle: 'none' | 'bracket-n'` (default: `'none'`)
- In `bracket-n` mode (strict terminal wildcard pattern), render repeat notation with:
  - bracket + `n`
  - continuation stubs crossing the brackets
  - hidden wildcard `*` labels and `*`-incident edges
- Keep the underlying molecular graph unchanged (display-only behavior)

## Activation rule

`bracket-n` activates only when all conditions match:

- exactly two wildcard atoms (`*`)
- each wildcard is terminal-like (`degree === 1`), non-ring, and not attached to another `*`
- one wildcard is parse-tree root (`parentVertexId === null`)
- one wildcard is main-chain tail (`children.length === 0`)

All other wildcard patterns fall back to default rendering.

## Why this shape

- Align polymer repeat rendering with common reader expectations (`[ ]n` + continuation stubs)
- Use structural terminal wildcard detection (not first/last atom position heuristics)

## Tests

- Added unit coverage for overlay state guard behavior:
  - `test/unit/polymerRepeatUnitOverlay.test.js`
- Added regression rendering coverage for:
  - valid terminal wildcard activation
  - `*CC(=O)O*` tail detection case
  - disabled mode fallback
  - non-terminal / single / >2 wildcard fallback cases
  - `test/regression/rendering.test.js`
- Verified:
  - `npm run test:unit`

## Notes

- Built on top of latest `master` (post-2.3.0)
- This PR supersedes earlier exploratory branch/PR work