### PR TITLE
Fix wedges not being drawn when explicitHydrogens is false.

### DIFF
--- a/src/Atom.js
+++ b/src/Atom.js
@@ -32,7 +32,6 @@ import ArrayHelper from './ArrayHelper';
  * @property {String} chirality The chirality of this atom if it is a stereocenter (R or S).
  * @property {Number} priority The priority of this atom acording to the CIP rules, where 0 is the highest priority.
  * @property {Boolean} mainChain A boolean indicating whether or not this atom is part of the main chain (used for chirality).
- * @property {String} hydrogenDirection The direction of the hydrogen, either up or down. Only for stereocenters with and explicit hydrogen.
  * @property {Number} subtreeDepth The depth of the subtree coming from a stereocenter.
  * @property {Number} class
  */
@@ -69,9 +68,7 @@ export default class Atom {
         this.isStereoCenter = false;
         this.priority = 0;
         this.mainChain = false;
-        this.hydrogenDirection = 'down';
         this.subtreeDepth = 1;
-        this.hasHydrogen = false;
         this.class = undefined;
     }
 

--- a/src/CIP.ts
+++ b/src/CIP.ts
@@ -330,7 +330,7 @@ export class CIPTree {
  * @see https://ursula.chem.yale.edu/~chem220/chem220js/STUDYAIDS/isomers/RS14272/pinene.html
  */
 export default class CIP {
-    static getOrderArray(graph: Graph, vertex: Vertex): Uint8Array | undefined {
+    static getOrderArray(graph: Graph, vertex: Vertex): Array<number> | undefined {
         const root = CIPTree.build(graph, vertex);
 
         // If there are any non-stereo ties, this isn't a stereocenter!
@@ -342,7 +342,7 @@ export default class CIP {
 
         // Build the ordering array expected by DrawerBase._computeWedgeDirection().
         const nNeighbours = vertex.neighbours.length;
-        const order = new Uint8Array(nNeighbours);
+        const order = new Array(nNeighbours);
         for (let i = 0; i < nNeighbours; ++i) {
             const vid = root.children[i].vertex.id;
             order[i] = vertex.neighbours.findIndex(nid => nid === vid);

--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -942,26 +942,22 @@ export default class DrawerBase {
     }
 
     initHydrogens() {
-    // Do not draw hydrogens except when they are connected to a stereocenter connected to two or more rings.
-        if (!this.opts.explicitHydrogens) {
-            for (let i = 0; i < this.graph.vertices.length; i++) {
-                let vertex = this.graph.vertices[i];
+        if (this.opts.explicitHydrogens) {
+            return;
+        }
 
-                if (vertex.value.element !== 'H') {
-                    continue;
-                }
+        for (const vertex of this.graph.vertices) {
+            if (vertex.value.element !== 'H' || vertex.neighbours.length !== 1) {
+                continue;
+            }
 
-                // Hydrogens should have only one neighbour, so just take the first
-                // Also set hasHydrogen true on connected atom
-                let neighbour = this.graph.vertices[vertex.neighbours[0]];
-                neighbour.value.hasHydrogen = true;
-
-                if (!neighbour.value.isStereoCenter
-                    || (neighbour.value.rings.length < 2 && !neighbour.value.bridgedRing)
-                    || (neighbour.value.bridgedRing && neighbour.value.originalRings.length < 2)
-                ) {
-                    vertex.value.isDrawn = false;
-                }
+            const neighbour = this.graph.vertices[vertex.neighbours[0]];
+            if (!neighbour.value.isStereoCenter
+                || (neighbour.value.rings.length < 2 && !neighbour.value.bridgedRing)
+                || (neighbour.value.bridgedRing && neighbour.value.originalRings.length < 2)
+            ) {
+                // This vertex can be safely hidden.
+                vertex.value.isDrawn = false;
             }
         }
     }
@@ -3276,34 +3272,32 @@ export default class DrawerBase {
 
             // Pick best neighbor to draw wedge on.
             // Priority: non-stereocenter > outside ring > heteroatom > shortest subtree
-            let wedgeOrder = new Array(neighbours.length - 1);
-            let showHydrogen = vertex.value.rings.length > 1 && vertex.value.hasHydrogen;
-            let offset = vertex.value.hasHydrogen ? 1 : 0;
+            const wedgeOrder = order.map((o) => {
+                const nid       = neighbours[o];
+                const neighbour = this.graph.vertices[nid];
 
-            for (let j = 0; j < order.length - offset; j++) {
-                wedgeOrder[j] = new Uint32Array(2);
-                let neighbour = this.graph.vertices[neighbours[order[j]]];
-                wedgeOrder[j][0] += neighbour.value.isStereoCenter ? 0 : 100000;
-                wedgeOrder[j][0] += this.areVerticesInSameRing(neighbour, vertex) ? 0 : 10000;
-                wedgeOrder[j][0] += neighbour.value.isHeteroAtom() ? 1000 : 0;
-                wedgeOrder[j][0] -= neighbour.value.subtreeDepth === 0 ? 1000 : 0;
-                wedgeOrder[j][0] += 1000 - neighbour.value.subtreeDepth;
-                wedgeOrder[j][1] = neighbours[order[j]];
-            }
+                let rank = 0;
+                rank += neighbour.value.isStereoCenter ? 0 : 100000;
+                rank += this.areVerticesInSameRing(neighbour, vertex) ? 0 : 10000;
+                rank += neighbour.value.isHeteroAtom() ? 1000 : 0;
+                rank -= neighbour.value.subtreeDepth === 0 ? 1000 : 0;
+                rank += 1000 - neighbour.value.subtreeDepth;
 
-            wedgeOrder.sort((a, b) => b[0] - a[0]);
+                return [rank, nid];
+            }).sort((a, b) => {
+                return b[0] - a[0];
+            });
 
-            if (!showHydrogen) {
-                let wedgeId = wedgeOrder[0][1];
-                let wedge = this._computeWedgeDirection(vertex, wedgeId, order, neighbours, rs);
-                this.graph.getEdge(vertex.id, wedgeId).wedge = wedge;
+            // Set the wedge direction.
+            const wedgeId = wedgeOrder[0][1];
+            const wedge = this._computeWedgeDirection(vertex, wedgeId, order, neighbours, rs);
+            this.graph.getEdge(vertex.id, wedgeId).wedge = wedge;
 
-                if (vertex.value.hasHydrogen) {
-                    let hId = neighbours[order[order.length - 1]];
-                    let hWedge = this._computeWedgeDirection(vertex, hId, order, neighbours, rs);
-                    this.graph.getEdge(vertex.id, hId).wedge = hWedge;
-                    vertex.value.hydrogenDirection = hWedge === 'up' ? 'up' : 'down';
-                }
+            // If there's a hydrogen, give it a wedge, too.
+            const hId = neighbours[order[order.length - 1]];
+            if (this.graph.vertices[hId].value.element === 'H') {
+                const hWedge = this._computeWedgeDirection(vertex, hId, order, neighbours, rs);
+                this.graph.getEdge(vertex.id, hId).wedge = hWedge;
             }
         }
     }

--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -3270,18 +3270,20 @@ export default class DrawerBase {
             const rs       = (parity === rotation) ? 'R' : 'S';
             vertex.value.chirality = rs;
 
-            // Pick best neighbor to draw wedge on.
-            // Priority: non-stereocenter > outside ring > heteroatom > shortest subtree
+            // Pick the best neighbor to draw a wedge to.
+            // Priority: non-stereocenter > not in same ring > visible > heteroatom > shortest subtree
+            // Note that the sort order is reversed, so higher scores get priority.
             const wedgeOrder = order.map((o) => {
                 const nid       = neighbours[o];
                 const neighbour = this.graph.vertices[nid];
 
                 let rank = 0;
-                rank += neighbour.value.isStereoCenter ? 0 : 100000;
-                rank += this.areVerticesInSameRing(neighbour, vertex) ? 0 : 10000;
-                rank += neighbour.value.isHeteroAtom() ? 1000 : 0;
-                rank -= neighbour.value.subtreeDepth === 0 ? 1000 : 0;
-                rank += 1000 - neighbour.value.subtreeDepth;
+                rank -= neighbour.value.isStereoCenter ? 1000000 : 0;
+                rank -= this.areVerticesInSameRing(neighbour, vertex) ? 100000 : 0;
+                rank += neighbour.value.isDrawn ? 10000 : 0;
+                // rank += neighbour.isTerminal() ? 1000 : 0;
+                rank += neighbour.value.element !== 'C' ? 100 : 0;
+                rank -= this.graph.getTreeDepth(nid, vertex.id);
 
                 return [rank, nid];
             }).sort((a, b) => {
@@ -3292,13 +3294,7 @@ export default class DrawerBase {
             const wedgeId = wedgeOrder[0][1];
             const wedge = this._computeWedgeDirection(vertex, wedgeId, order, neighbours, rs);
             this.graph.getEdge(vertex.id, wedgeId).wedge = wedge;
-
-            // If there's a hydrogen, give it a wedge, too.
-            const hId = neighbours[order[order.length - 1]];
-            if (this.graph.vertices[hId].value.element === 'H') {
-                const hWedge = this._computeWedgeDirection(vertex, hId, order, neighbours, rs);
-                this.graph.getEdge(vertex.id, hId).wedge = hWedge;
-            }
+            this.graph.vertices[wedgeId].value.isDrawn = true;
         }
     }
 

--- a/test/regression/rs-stereo.test.js
+++ b/test/regression/rs-stereo.test.js
@@ -1,0 +1,206 @@
+/**
+ * R/S stereochemistry regression tests.
+ *
+ * Verifies that the expected (usually the shortest) branch
+ * around an R/S chiral center gets a drawn with a wedge.
+ */
+import {describe, it, expect, vi} from 'vitest';
+import {createJSDOM}              from '../helpers';
+
+import Parser    from '../../src/Parser';
+import SvgDrawer from '../../src/SvgDrawer';
+import Vector2   from '../../src/Vector2';
+
+const expectWedges = vi.defineHelper((graph, centerId, wedgeIds) => {
+    const center = graph.vertices[centerId];
+    for (const nid of center.neighbours) {
+        const text = `(${centerId} -> ${nid})`;
+        const edge = graph.getEdge(centerId, nid);
+        if (wedgeIds.includes(nid)) {
+            expect(edge.wedge, `Edge ${text} should be a wedge`).toBeOneOf(['up', 'down']);
+        }
+        else {
+            // Empty string or undefined or...
+            expect(edge.wedge, `Edge ${text} should NOT be a wedge`).toBeFalsy();
+        }
+    }
+});
+
+function render(smiles, options) {
+    const dom = createJSDOM();
+
+    const svg = dom.window.document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttributeNS(null, 'id', 'test-svg');
+    dom.window.document.body.appendChild(svg);
+
+    const tree = Parser.parse(smiles);
+    const drawer = new SvgDrawer(options);
+    drawer.draw(tree, svg, 'light', false);
+    return drawer.preprocessor;
+}
+
+/**
+ * Calculates the winding of several points around a center point.
+ *
+ * WARNING: This operates in SVG coordinates, not standard Cartesian coordinates!
+ * This means that increasing Y values move lower in space (lower on the screen),
+ * So the result is the opposite of what a mathematician would expect.
+ *
+ * @param {Point}   center - The center point.
+ * @param {Point[]} points - At least three points to calculate winding from.
+ * @returns -1 if the points wind clockwise, or 1 if they wind counterclockwise.
+ */
+function winding(center, points) {
+    const len = points.length;
+    if (len < 3) {
+        throw new Error('Three or more points are needed to determine winding.')
+    }
+
+    const angles = points.map((point, i) => {
+        return [i, Vector2.subtract(point, center).angle()];
+    }).sort((a, b) => {
+        return a[1] - b[1];
+    });
+
+    let wind = undefined;
+    let prev = angles[len - 1];
+    for (let i = 0; i < len; ++i) {
+        const curr = angles[i];
+        const w    = (curr[0] - prev[0] + len) % len;
+        if (wind !== undefined && w !== wind) {
+            throw new Error('Inconsistent winding!');
+        }
+        if (w !== 1 && w !== len - 1) {
+            throw new Error('Inconsistent winding!');
+        }
+
+        prev = curr;
+        wind = w;
+    }
+
+    // wind == 1        =>  clockwise
+    // wind == len - 1  =>  counterclockwise
+    return (wind > 1) ? 1 : -1;
+}
+
+function getWinding(graph, cid, nids) {
+    const center = graph.vertices[cid].position;
+    const points = nids.map(nid => graph.vertices[nid].position);
+    return winding(center, points);
+}
+
+describe('winding()', () => {
+    //  Yes, this is a test for a test helper function...
+    it('should throw when given two or fewer points', () => {
+        expect(() => winding(new Vector2(0, 0), [
+            new Vector2(1, 0),
+            new Vector2(0, 1),
+        ])).toThrow();
+    });
+
+    it('should return -1 when the winding is clockwise', () => {
+        // Computer graphics use an inverted Y axis!
+        expect(winding(new Vector2(0, 0), [
+            new Vector2(1, 0),
+            new Vector2(0, 1),
+            new Vector2(-1, 0),
+            new Vector2(0, -1),
+        ])).toBe(-1);
+    });
+
+    it('should return +1 when the winding is counterclockwise', () => {
+        // Computer graphics use an inverted Y axis!
+        expect(winding(new Vector2(0, 0), [
+            new Vector2(1, 0),
+            new Vector2(0, -1),
+            new Vector2(-1, 0),
+            new Vector2(0, 1),
+        ])).toBe(+1);
+    });
+
+    it('should throw when the winding is invalid', () => {
+        expect(() => winding(new Vector2(0, 0), [
+            new Vector2(1, 0),
+            new Vector2(-1, 0),
+            new Vector2(0, -1),
+            new Vector2(0, 1),
+        ])).toThrow();
+    });
+});
+
+describe('R/S visual chirality', () => {
+    it('prefers to put wedges towards atoms not in the same ring', () => {
+        let pp = render('C[C@H]1CCCC(C)C1', {explicitHydrogens: false});
+        expectWedges(pp.graph, 1, [0]);
+
+        pp = render('C1CC[C@H](C)CC1C', {explicitHydrogens: false});
+        expectWedges(pp.graph, 3, [5]);
+    });
+
+    it('prefers to put wedges towards heteroatoms', () => {
+        let pp = render('C=N[C@](CN)(C)CC');
+        expectWedges(pp.graph, 2, [1]);
+
+        pp = render('C#C[C@](C)(B)CC');
+        expectWedges(pp.graph, 2, [4]);
+
+        pp = render('C#C[C@](CF)(C)OCC');
+        expectWedges(pp.graph, 2, [6]);
+    });
+
+    it('prefers to put wedges towards the shortest subtree', () => {
+        // This was a bug (no GitHub issue) as of v2.3.0.
+        // The old code used atom.subtreeDepth without recalculating it from
+        // the chiral center, so it got whatever had been cached earlier.
+        let pp = render('C[C@](CC)(CCC)CCCC');
+        expectWedges(pp.graph, 1, [0]);
+
+        pp = render('CC[C@](C)(CCC)CCCC');
+        expectWedges(pp.graph, 2, [3]);
+
+        pp = render('CCC[C@](CC)(C)CCCC');
+        expectWedges(pp.graph, 3, [6]);
+
+        pp = render('CCC[C@](CC)(CCCC)C');
+        expectWedges(pp.graph, 3, [10]);
+    });
+
+    it('adds hidden hydrogens back when necessary', () => {
+        // In particular, when all other neighbors are stereocenters or in the same ring.
+        let pp = render('[C@H]12CCCC[C@H]1CCCC2', {explicitHydrogens: false});
+        expect(pp.graph.vertices[1].value.isDrawn).toBe(true);
+        expect(pp.graph.vertices[7].value.isDrawn).toBe(true);
+        expectWedges(pp.graph, 0, [1]);
+        expectWedges(pp.graph, 6, [7]);
+    });
+
+    it('shows R/S stereochemistry when hydrogens are explicit', () => {
+        // https://github.com/reymond-group/smilesDrawer/pull/287#pullrequestreview-4273681678
+        let pp = render('[C@@H](CC)(CCC)CCCC', {explicitHydrogens: true});
+        let cw = getWinding(pp.graph, 0, [2, 4, 7]) < 0;
+        expect.soft(pp.graph.getEdge(0, 1).wedge).toBe(cw ? 'up' : 'down'); // H
+
+        pp = render('CC[C@@H](CCC)CCCC', {explicitHydrogens: true});
+        cw = getWinding(pp.graph, 2, [1, 4, 7]) < 0;
+        expect.soft(pp.graph.getEdge(2, 3).wedge).toBe(cw ? 'down' : 'up'); // H
+
+        pp = render('CC[C@H](CCC(C)C)CCCC', {explicitHydrogens: true});
+        cw = getWinding(pp.graph, 2, [1, 9, 4]) < 0;
+        expect.soft(pp.graph.getEdge(2, 3).wedge).toBe(cw ? 'down' : 'up'); // H
+    });
+
+    it('shows R/S stereochemistry when explicit hydrogens are hidden', () => {
+        // https://github.com/reymond-group/smilesDrawer/pull/287#pullrequestreview-4273681678
+        let pp = render('[C@@H](CC)(CCC)CCCC', {explicitHydrogens: false});
+        let cw = getWinding(pp.graph, 0, [2, 4, 7]) < 0;
+        expect.soft(pp.graph.getEdge(0, 2).wedge).toBe(cw ? 'down' : 'up');
+
+        pp = render('CC[C@@H](CCC)CCCC', {explicitHydrogens: false});
+        cw = getWinding(pp.graph, 2, [1, 4, 7]) < 0;
+        expect.soft(pp.graph.getEdge(2, 1).wedge).toBe(cw ? 'up' : 'down');
+
+        pp = render('CC[C@H](CCC(C)C)CCCC', {explicitHydrogens: false});
+        cw = getWinding(pp.graph, 2, [1, 9, 4]) < 0;
+        expect.soft(pp.graph.getEdge(2, 1).wedge).toBe(cw ? 'up' : 'down');
+    });
+});


### PR DESCRIPTION
Fixes #286.

The main change here is that the code to set wedge direction is no longer in a conditional.  Everything else is just cleanup that I did while debugging.  Mainly: the `hydrogenDirection` attribute was never used, and the `hasHydrogen` attribute was only used in ways I didn't understand, and we seem to be just fine (better, even) without it.