### PR TITLE
Fix Straight Bond Labels

### DIFF
--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -2745,11 +2745,11 @@ export default class DrawerBase {
                 if (prevEdge && nextEdge && prevEdge.weight + nextEdge.weight >= 4) {
                     prevEdge.center = true;
                     nextEdge.center = true;
-
-                    // TODO: One of these is on value, but the other isn't?
-                    vertex.value.drawExplicit = false;
-                    nextVertex.drawExplicit = true;
                     nextVertex.angle = 0.0;
+
+                    if (prevEdge.weight === nextEdge.weight) {
+                        vertex.value.drawExplicit = true;
+                    }
 
                     this.createNextBond(nextVertex, vertex, previousAngle + nextVertex.angle);
                 }

--- a/test/regression/rendering.test.js
+++ b/test/regression/rendering.test.js
@@ -3,7 +3,7 @@
  * (parser -> graph -> layout -> SVG) and cover structural motifs that
  * have caused bugs or are otherwise tricky.
  *
- * If a new bug is found, SMILES cna be added here before fixing it.
+ * If a new bug is found, SMILES can be added here before fixing it.
  */
 import {describe, it, expect} from 'vitest';
 import {createJSDOM}          from '../helpers';
@@ -26,6 +26,7 @@ function assertRendersToSVG(smiles) {
 
     const pp = drawer.preprocessor;
     expect(pp.graph.vertices.length).toBeGreaterThan(0);
+    return pp;
 }
 
 // Basic structural motifs one representative per category
@@ -78,7 +79,7 @@ describe('Rendering: regression cases', () => {
     }
 });
 
-// Complex molecules 
+// Complex molecules
 describe('Rendering: complex molecules', () => {
     const cases = [
         ['strychnine', 'O=C1CC2CC3CC4(OCC=C4CC3N2C5=CC=CC1=C5)C=O'],
@@ -90,4 +91,32 @@ describe('Rendering: complex molecules', () => {
     for (const [name, smiles] of cases) {
         it(`${name}: ${smiles}`, () => assertRendersToSVG(smiles));
     }
+});
+
+describe('Rendering: straight chains', () => {
+    it('should label carbons between pairs of double bonds', () => {
+        let pp = assertRendersToSVG('O=C=O');
+        expect(pp.graph.vertices[1].value.drawExplicit).toBe(true);
+
+        pp = assertRendersToSVG('C=C=C');
+        expect(pp.graph.vertices[1].value.drawExplicit).toBe(true);
+    });
+
+    it('should not label carbons at the ends of straight chains', () => {
+        let pp = assertRendersToSVG('C=C=C=CC');
+        expect(pp.graph.vertices[0].value.drawExplicit).toBe(false);
+        expect(pp.graph.vertices[3].value.drawExplicit).toBe(false);
+
+        pp = assertRendersToSVG('CC=C=C=C');
+        expect(pp.graph.vertices[1].value.drawExplicit).toBe(false);
+        expect(pp.graph.vertices[4].value.drawExplicit).toBe(false);
+    });
+
+    it('should not label carbons if the two bonds are of different orders', () => {
+        const pp = assertRendersToSVG('C#CC#C');
+        expect(pp.graph.vertices[0].value.drawExplicit).toBe(false);
+        expect(pp.graph.vertices[1].value.drawExplicit).toBe(false);
+        expect(pp.graph.vertices[2].value.drawExplicit).toBe(false);
+        expect(pp.graph.vertices[3].value.drawExplicit).toBe(false);
+    });
 });


### PR DESCRIPTION
This adds explicit labels to atoms between pairs of symmetric, straight bonds, like the carbon in carbon dioxide (`O=C=O`).  I'm pretty sure that's what the original code was trying to do, but it didn't...  I've fixed it and added some tests.