### PR TITLE
fix: improve robustness of JSON parsing in data attributes

### DIFF
--- a/src/SmilesDrawer.js
+++ b/src/SmilesDrawer.js
@@ -66,12 +66,22 @@ export default class SmilesDrawer {
             if (element.hasAttribute('data-smiles-options') || element.hasAttribute('data-smiles-reaction-options')) {
                 let moleculeOptions = {};
                 if (element.hasAttribute('data-smiles-options')) {
-                    moleculeOptions = JSON.parse(element.getAttribute('data-smiles-options').replace(/'/g, '"'));
+                    const attr = element.getAttribute('data-smiles-options');
+                    try {
+                        moleculeOptions = JSON.parse(attr);
+                    } catch (e) {
+                        moleculeOptions = JSON.parse(attr.replace(/'/g, '"'));
+                    }
                 }
 
                 let reactionOptions = {};
                 if (element.hasAttribute('data-smiles-reaction-options')) {
-                    reactionOptions = JSON.parse(element.getAttribute('data-smiles-reaction-options').replace(/'/g, '"'));
+                    const attr = element.getAttribute('data-smiles-reaction-options');
+                    try {
+                        reactionOptions = JSON.parse(attr);
+                    } catch (e) {
+                        reactionOptions = JSON.parse(attr.replace(/'/g, '"'));
+                    }
                 }
 
                 let smilesDrawer = new SmilesDrawer(moleculeOptions, reactionOptions);
@@ -85,12 +95,12 @@ export default class SmilesDrawer {
 
     /**
      * Draw the smiles to the target.
-     * @param {String} smiles The SMILES to be depicted.
-     * @param {*} target The target element.
-     * @param {String} theme The theme.
-     * @param {?CallableFunction} successCallback The function called on success.
-     * @param {?CallableFunction} errorCallback The function called on error.
-     * @param {?Number[]|Object} weights The weights for the gaussians.
+     * @scripts/params.mjs {String} smiles The SMILES to be depicted.
+     * @scripts/params.mjs {*} target The target element.
+     * @scripts/params.mjs {String} theme The theme.
+     * @scripts/params.mjs {?CallableFunction} successCallback The function called on success.
+     * @scripts/params.mjs {?CallableFunction} errorCallback The function called on error.
+     * @scripts/params.mjs {?Number[]|Object} weights The weights for the gaussians.
      */
     draw(smiles, target, theme = 'light', successCallback = null, errorCallback = null, weights = null) {
         // get the settings
@@ -106,7 +116,11 @@ export default class SmilesDrawer {
                 info.lastIndexOf('__')
             );
 
-            settings = JSON.parse(settingsString.replace(/'/g, '"'));
+            try {
+                settings = JSON.parse(settingsString);
+            } catch (e) {
+                settings = JSON.parse(settingsString.replace(/'/g, '"'));
+            }
         }
 
         let defaultSettings = {
@@ -304,8 +318,8 @@ export default class SmilesDrawer {
 
     /**
      *
-     * @param {HTMLImageElement|HTMLCanvasElement|SVGElement} element
-     * @param {SVGElement} svg
+     * @scripts/params.mjs {HTMLImageElement|HTMLCanvasElement|SVGElement} element
+     * @scripts/params.mjs {SVGElement} svg
      * @returns {{w: Number, h: Number}} The width and height.
      */
     getDimensions(element, svg = null) {

--- a/src/SmilesDrawer.js
+++ b/src/SmilesDrawer.js
@@ -95,12 +95,12 @@ export default class SmilesDrawer {
 
     /**
      * Draw the smiles to the target.
-     * @scripts/params.mjs {String} smiles The SMILES to be depicted.
-     * @scripts/params.mjs {*} target The target element.
-     * @scripts/params.mjs {String} theme The theme.
-     * @scripts/params.mjs {?CallableFunction} successCallback The function called on success.
-     * @scripts/params.mjs {?CallableFunction} errorCallback The function called on error.
-     * @scripts/params.mjs {?Number[]|Object} weights The weights for the gaussians.
+     * @param {String} smiles The SMILES to be depicted.
+     * @param {*} target The target element.
+     * @param {String} theme The theme.
+     * @param {?CallableFunction} successCallback The function called on success.
+     * @param {?CallableFunction} errorCallback The function called on error.
+     * @param {?Number[]|Object} weights The weights for the gaussians.
      */
     draw(smiles, target, theme = 'light', successCallback = null, errorCallback = null, weights = null) {
         // get the settings
@@ -318,8 +318,8 @@ export default class SmilesDrawer {
 
     /**
      *
-     * @scripts/params.mjs {HTMLImageElement|HTMLCanvasElement|SVGElement} element
-     * @scripts/params.mjs {SVGElement} svg
+     * @param {HTMLImageElement|HTMLCanvasElement|SVGElement} element
+     * @param {SVGElement} svg
      * @returns {{w: Number, h: Number}} The width and height.
      */
     getDimensions(element, svg = null) {

--- a/test/unit/SmilesDrawer.test.js
+++ b/test/unit/SmilesDrawer.test.js
@@ -1,4 +1,4 @@
-import {describe, it, expect, beforeEach} from 'vitest';
+import {describe, it, expect, beforeEach, vi} from 'vitest';
 import {JSDOM} from 'jsdom';
 import SmilesDrawer from '../../src/SmilesDrawer.js';
 
@@ -24,22 +24,39 @@ describe('SmilesDrawer', () => {
         element.setAttribute('data-smiles-options', '{"width": 500}');
         document.body.appendChild(element);
 
+        const drawSpy = vi.spyOn(SmilesDrawer.prototype, 'draw');
         const drawer = new SmilesDrawer();
-        expect(() => {
-            drawer.apply('data-smiles');
-        }).not.toThrow();
+        drawer.apply('data-smiles');
+
+        const instance = drawSpy.mock.instances[0];
+        expect(instance.drawer.opts.width).toBe(500);
     });
 
     it('should parse JSON options with single quotes as fallback', () => {
         const element = document.createElement('div');
         element.setAttribute('data-smiles', 'C');
-        element.setAttribute('data-smiles-options', '{"width": 500}'); // This actually uses double quotes, testing the fallback mechanism with a slightly different input
-        // The test is to ensure it handles JSON gracefully, and the fallback doesn't break valid JSON
+        element.setAttribute('data-smiles-options', "{'width': 500}");
         document.body.appendChild(element);
 
+        const drawSpy = vi.spyOn(SmilesDrawer.prototype, 'draw');
         const drawer = new SmilesDrawer();
-        expect(() => {
-            drawer.apply('data-smiles');
-        }).not.toThrow();
+        drawer.apply('data-smiles');
+
+        const instance = drawSpy.mock.instances[0];
+        expect(instance.drawer.opts.width).toBe(500);
+    });
+
+    it('should parse valid JSON containing an apostrophe without corruption', () => {
+        const element = document.createElement('div');
+        element.setAttribute('data-smiles', 'C');
+        element.setAttribute('data-smiles-options', '{"label": "John\'s"}');
+        document.body.appendChild(element);
+
+        const drawSpy = vi.spyOn(SmilesDrawer.prototype, 'draw');
+        const drawer = new SmilesDrawer();
+        drawer.apply('data-smiles');
+
+        const instance = drawSpy.mock.instances[0];
+        expect(instance.drawer.opts.label).toBe("John's");
     });
 });

--- a/test/unit/SmilesDrawer.test.js
+++ b/test/unit/SmilesDrawer.test.js
@@ -1,0 +1,45 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import {JSDOM} from 'jsdom';
+import SmilesDrawer from '../../src/SmilesDrawer.js';
+
+describe('SmilesDrawer', () => {
+    beforeEach(() => {
+        const dom = new JSDOM('<!DOCTYPE html><html><body><div id="target" data-smiles="C"></div></body></html>');
+        global.document = dom.window.document;
+        global.window = dom.window;
+        global.HTMLElement = dom.window.HTMLElement;
+        global.HTMLImageElement = dom.window.HTMLImageElement;
+        global.HTMLCanvasElement = dom.window.HTMLCanvasElement;
+        global.SVGElement = dom.window.SVGElement;
+    });
+
+    it('should be instantiable', () => {
+        const drawer = new SmilesDrawer();
+        expect(drawer).toBeDefined();
+    });
+
+    it('should parse valid JSON options', () => {
+        const element = document.createElement('div');
+        element.setAttribute('data-smiles', 'C');
+        element.setAttribute('data-smiles-options', '{"width": 500}');
+        document.body.appendChild(element);
+
+        const drawer = new SmilesDrawer();
+        expect(() => {
+            drawer.apply('data-smiles');
+        }).not.toThrow();
+    });
+
+    it('should parse JSON options with single quotes as fallback', () => {
+        const element = document.createElement('div');
+        element.setAttribute('data-smiles', 'C');
+        element.setAttribute('data-smiles-options', '{"width": 500}'); // This actually uses double quotes, testing the fallback mechanism with a slightly different input
+        // The test is to ensure it handles JSON gracefully, and the fallback doesn't break valid JSON
+        document.body.appendChild(element);
+
+        const drawer = new SmilesDrawer();
+        expect(() => {
+            drawer.apply('data-smiles');
+        }).not.toThrow();
+    });
+});

--- a/test/unit/SmilesDrawer.test.js
+++ b/test/unit/SmilesDrawer.test.js
@@ -19,40 +19,46 @@ describe('SmilesDrawer', () => {
     });
 
     it('should parse valid JSON options', () => {
+        document.getElementById('target').remove();
         const element = document.createElement('div');
         element.setAttribute('data-smiles', 'C');
-        element.setAttribute('data-smiles-options', '{"width": 500}');
+        element.setAttribute('data-smiles-options', '{"width": 1234}');
         document.body.appendChild(element);
 
         const drawSpy = vi.spyOn(SmilesDrawer.prototype, 'draw');
+        drawSpy.mockClear();
         const drawer = new SmilesDrawer();
         drawer.apply('data-smiles');
 
         const instance = drawSpy.mock.instances[0];
-        expect(instance.drawer.opts.width).toBe(500);
+        expect(instance.drawer.opts.width).toBe(1234);
     });
 
     it('should parse JSON options with single quotes as fallback', () => {
+        document.getElementById('target').remove();
         const element = document.createElement('div');
         element.setAttribute('data-smiles', 'C');
-        element.setAttribute('data-smiles-options', "{'width': 500}");
+        element.setAttribute('data-smiles-options', "{'width': 1234}");
         document.body.appendChild(element);
 
         const drawSpy = vi.spyOn(SmilesDrawer.prototype, 'draw');
+        drawSpy.mockClear();
         const drawer = new SmilesDrawer();
         drawer.apply('data-smiles');
 
         const instance = drawSpy.mock.instances[0];
-        expect(instance.drawer.opts.width).toBe(500);
+        expect(instance.drawer.opts.width).toBe(1234);
     });
 
     it('should parse valid JSON containing an apostrophe without corruption', () => {
+        document.getElementById('target').remove();
         const element = document.createElement('div');
         element.setAttribute('data-smiles', 'C');
         element.setAttribute('data-smiles-options', '{"label": "John\'s"}');
         document.body.appendChild(element);
 
         const drawSpy = vi.spyOn(SmilesDrawer.prototype, 'draw');
+        drawSpy.mockClear();
         const drawer = new SmilesDrawer();
         drawer.apply('data-smiles');
 


### PR DESCRIPTION
The JSON parsing for data-smiles-options and data-smiles-reaction-options was fragile, blindly replacing single quotes with double quotes, which could corrupt valid JSON strings. This change attempts to parse the attribute value directly as JSON first, falling back to the quote-replacement method only if initial parsing fails. This improves reliability for users providing valid JSON while maintaining backward compatibility for attributes using single quotes. Added a basic test suite for SmilesDrawer as well.