### PR TITLE
Fix a couple of bugs that caused rendering failures in JSDOM.

### DIFF
--- a/src/SvgWrapper.js
+++ b/src/SvgWrapper.js
@@ -1009,7 +1009,7 @@ export default class SvgWrapper {
         svg.setAttributeNS(null, 'width', width);
         svg.setAttributeNS(null, 'height', height);
 
-        let image = new Image();
+        let image = document.createElement('img');
         image.onload = function() {
             canvas.width = width;
             canvas.height = height;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -7,6 +7,12 @@ export function createJSDOM(options) {
     global.document = dom.window.document;
     global.window   = dom.window;
 
+    // Add the global types that we understand and can draw to:
+    global.HTMLImageElement  = dom.window.HTMLImageElement;
+    global.HTMLCanvasElement = dom.window.HTMLCanvasElement;
+    global.OffscreenCanvas   = dom.window.HTMLCanvasElement; // HACK! Not supported by JSDOM.
+    global.SVGElement        = dom.window.SVGElement;        // TODO: Use SVGSVGElement.
+
     if (options.patchCanvasGetContext !== false) {
         // Suppress the bajillion copies of this warning message that get written to stderr:
         // Not implemented: HTMLCanvasElement's getContext() method: without installing the canvas npm package

--- a/test/unit/SmilesDrawer.test.js
+++ b/test/unit/SmilesDrawer.test.js
@@ -1,26 +1,19 @@
-import {describe, it, expect, beforeEach, vi} from 'vitest';
-import {JSDOM} from 'jsdom';
+import {describe, it, expect, vi} from 'vitest';
+import {createJSDOM}              from '../helpers';
+
 import SmilesDrawer from '../../src/SmilesDrawer.js';
 
 describe('SmilesDrawer', () => {
-    beforeEach(() => {
-        const dom = new JSDOM('<!DOCTYPE html><html><body><div id="target" data-smiles="C"></div></body></html>');
-        global.document = dom.window.document;
-        global.window = dom.window;
-        global.HTMLElement = dom.window.HTMLElement;
-        global.HTMLImageElement = dom.window.HTMLImageElement;
-        global.HTMLCanvasElement = dom.window.HTMLCanvasElement;
-        global.SVGElement = dom.window.SVGElement;
-    });
-
     it('should be instantiable', () => {
         const drawer = new SmilesDrawer();
         expect(drawer).toBeDefined();
     });
 
     it('should parse valid JSON options', () => {
-        document.getElementById('target').remove();
-        const element = document.createElement('div');
+        createJSDOM();
+
+        // Canvases are kinda broken in JSDOM...
+        const element = document.createElement('img');
         element.setAttribute('data-smiles', 'C');
         element.setAttribute('data-smiles-options', '{"width": 1234}');
         document.body.appendChild(element);
@@ -35,8 +28,9 @@ describe('SmilesDrawer', () => {
     });
 
     it('should parse JSON options with single quotes as fallback', () => {
-        document.getElementById('target').remove();
-        const element = document.createElement('div');
+        createJSDOM();
+
+        const element = document.createElement('img');
         element.setAttribute('data-smiles', 'C');
         element.setAttribute('data-smiles-options', "{'width': 1234}");
         document.body.appendChild(element);
@@ -51,8 +45,9 @@ describe('SmilesDrawer', () => {
     });
 
     it('should parse valid JSON containing an apostrophe without corruption', () => {
-        document.getElementById('target').remove();
-        const element = document.createElement('div');
+        createJSDOM();
+
+        const element = document.createElement('img');
         element.setAttribute('data-smiles', 'C');
         element.setAttribute('data-smiles-options', '{"label": "John\'s"}');
         document.body.appendChild(element);


### PR DESCRIPTION
The new JSON parsing tests from #295 tried to render to `div`s, which isn't supported.  I think the tests still worked as intended, but there was error output to the console, and I figure it's cleaner to do things correctly.  I've also pulled the relevant setup code into the shared `createJSDOM()` helper function.

Also note that I had to use `img` elements here because JSDOM `canvas`es aren't fully implemented, and `x instanceof HTMLCanvasElement` always gives false.